### PR TITLE
fix(cluster): add ready condition when api discovery fails

### DIFF
--- a/cmd/controller-manager/app/util.go
+++ b/cmd/controller-manager/app/util.go
@@ -145,6 +145,7 @@ func createControllerContext(opts *options.Options) (*controllercontext.Context,
 func getComponentConfig(opts *options.Options) (*controllercontext.ComponentConfig, error) {
 	componentConfig := &controllercontext.ComponentConfig{
 		FederatedTypeConfigCreateCRDsForFTCs: opts.CreateCRDsForFTCs,
+		ClusterJoinTimeout:                   opts.ClusterJoinTimeout,
 	}
 
 	if opts.NSAutoPropExcludeRegexp != "" {

--- a/pkg/controllers/federatedcluster/clusterstatus.go
+++ b/pkg/controllers/federatedcluster/clusterstatus.go
@@ -44,7 +44,7 @@ import (
 
 const (
 	ClusterReadyReason  = "ClusterReady"
-	ClusterReadyMessage = "/healthz responded with ok"
+	ClusterReadyMessage = "Cluster is ready"
 
 	ClusterHealthzNotOKReason  = "HealthzNotOK"
 	ClusterHealthzNotOKMessage = "/healthz responded without ok"
@@ -56,9 +56,9 @@ const (
 	ClusterAPIDiscoveryFailedMessageTemplate = "Failed to discover cluster API resources: %v"
 
 	ClusterReachableReason    = "ClusterReachable"
-	ClusterReachableMsg       = "cluster is reachable"
+	ClusterReachableMsg       = "Cluster is reachable"
 	ClusterNotReachableReason = "ClusterNotReachable"
-	ClusterNotReachableMsg    = "cluster is not reachable"
+	ClusterNotReachableMsg    = "Cluster is not reachable"
 )
 
 func collectIndividualClusterStatus(

--- a/pkg/controllers/federatedcluster/util.go
+++ b/pkg/controllers/federatedcluster/util.go
@@ -78,30 +78,17 @@ func getNewClusterOfflineCondition(
 
 func getNewClusterReadyCondition(
 	status corev1.ConditionStatus,
+	reason, message string,
 	conditionTime metav1.Time,
 ) fedcorev1a1.ClusterCondition {
 	condition := fedcorev1a1.ClusterCondition{
 		Type:               fedcorev1a1.ClusterReady,
+		Status:             status,
+		Reason:             &reason,
+		Message:            &message,
 		LastProbeTime:      conditionTime,
 		LastTransitionTime: &conditionTime,
 	}
-
-	var reason, message string
-	switch status {
-	case corev1.ConditionTrue:
-		reason = ClusterReadyReason
-		message = ClusterReadyMessage
-	case corev1.ConditionFalse:
-		reason = ClusterNotReadyReason
-		message = ClusterNotReadyMessage
-	case corev1.ConditionUnknown:
-		reason = ClusterNotReachableReason
-		message = ClusterNotReachableMsg
-	}
-
-	condition.Status = status
-	condition.Reason = &reason
-	condition.Message = &message
 
 	return condition
 }


### PR DESCRIPTION
When api discovery for a member cluster fails, the cluster controller errors out and does not set the ready and offline conditions on the `FederatedCluster`. This PR updates the status update logic to also set ready and offline conditions (with new reasons explaining the issue) when api discovery or resource collection for a cluster fails.

This PR also fixes a regression where cluster join timeout defaults to 0 seconds, and makes cluster condition matching in e2e tests more stringent.