### PR TITLE
Webhook plugin integration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -160,9 +160,12 @@ linters-settings:
       - pkg: github.com/kubewharf/kubeadmiral/pkg/apis/schedulerwebhook/(?P<s1>v\d+)((?P<s2>\w)\w+(?P<s3>\d+))?
         # schedwebhookv1a1
         alias: schedwebhook${s1}${s2}${s3}
-      - pkg: github.com/kubewharf/kubeadmiral/pkg/apis/(?P<group>[\w\d]+)/(?P<s1>v\d+)((?P<s2>\w)\w+(?P<s3>\d+))?
+      - pkg: github.com/kubewharf/kubeadmiral/pkg/apis/core/(?P<s1>v\d+)((?P<s2>\w)\w+(?P<s3>\d+))?
         # fedcorev1a1
-        alias: fed${group}${s1}${s2}${s3}
+        alias: fedcore${s1}${s2}${s3}
+      - pkg: github.com/kubewharf/kubeadmiral/pkg/apis/types/(?P<s1>v\d+)((?P<s2>\w)\w+(?P<s3>\d+))?
+        # fedtypesv1a1
+        alias: fedtypes${s1}${s2}${s3}
 
       - pkg: k8s.io/client-go/kubernetes/typed/(?P<group>[\w\d]+)/(?P<s1>v\d+)((?P<s2>\w)\w+(?P<s3>\d+))?
         alias: ${group}${s1}${s2}${s3}client

--- a/cmd/controller-manager/app/core.go
+++ b/cmd/controller-manager/app/core.go
@@ -141,6 +141,7 @@ func startGlobalScheduler(
 	federatedGVR := schemautil.APIResourceToGVR(&federatedAPIResource)
 
 	scheduler, err := scheduler.NewScheduler(
+		klog.FromContext(ctx),
 		typeConfig,
 		controllerCtx.KubeClientset,
 		controllerCtx.FedClientset,

--- a/examples/scheduler/webhook/main.go
+++ b/examples/scheduler/webhook/main.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"math"
+	"net/http"
+	"strings"
+
+	"github.com/davecgh/go-spew/spew"
+
+	webhookv1a1 "github.com/kubewharf/kubeadmiral/pkg/apis/schedulerwebhook/v1alpha1"
+)
+
+var (
+	port = flag.Int("port", 50051, "The server port")
+)
+
+func doFilter(req *webhookv1a1.FilterRequest) *webhookv1a1.FilterResponse {
+	log.Printf("Received filter request\nScheduling unit: %s: Cluster: %s\n", spew.Sdump(req.SchedulingUnit), spew.Sdump(req.Cluster))
+
+	return &webhookv1a1.FilterResponse{
+		// This plugin filters out clusters with the digit '1' in their name
+		Selected: !strings.Contains(req.Cluster.Name, "1"),
+		Error:    "",
+	}
+}
+
+func doScore(req *webhookv1a1.ScoreRequest) *webhookv1a1.ScoreResponse {
+	log.Printf("Received score request\nScheduling unit: %s: Cluster: %s\n", spew.Sdump(req.SchedulingUnit), spew.Sdump(req.Cluster))
+
+	return &webhookv1a1.ScoreResponse{
+		// this score plugin scores clusters based on the number of characters in their name
+		Score: int64(len(req.Cluster.Name)),
+		Error: "",
+	}
+}
+
+func doSelect(req *webhookv1a1.SelectRequest) *webhookv1a1.SelectResponse {
+	log.Printf("Received select request\nScheduling unit: %s: Scores: %s\n", spew.Sdump(req.SchedulingUnit), spew.Sdump(req.ClusterScores))
+
+	// this score plugin always removes the lowest scoring cluster
+	lowestScoreIdx := 0
+	lowestScore := int64(math.MaxInt64)
+	for i, score := range req.ClusterScores {
+		if score.Score < lowestScore {
+			lowestScore = score.Score
+			lowestScoreIdx = i
+		}
+	}
+
+	selectedClusters := []string{}
+	for i, score := range req.ClusterScores {
+		if i == lowestScoreIdx {
+			continue
+		}
+		selectedClusters = append(selectedClusters, score.Cluster.Name)
+	}
+
+	return &webhookv1a1.SelectResponse{
+		SelectedClusterNames: selectedClusters,
+		Error:                "",
+	}
+}
+
+func processRequest[Req any, Resp any](
+	httpRespWriter http.ResponseWriter,
+	httpReq *http.Request,
+	handler func(req *Req) *Resp,
+) {
+	// Validate and decode the requeset
+	if httpReq.Method != http.MethodPost {
+		http.Error(httpRespWriter, "only POST requests are allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	req := new(Req)
+	if err := json.NewDecoder(httpReq.Body).Decode(req); err != nil {
+		http.Error(httpRespWriter, fmt.Sprintf("failed to decode request: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	// Run the scheduling logic
+	resp := handler(req)
+
+	// Encode and send the response
+	respBytes, err := json.Marshal(resp)
+	if err != nil {
+		http.Error(httpRespWriter, fmt.Sprintf("failed to encode response: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	httpRespWriter.Header().Set("Content-Type", "application/json")
+	httpRespWriter.Write(respBytes)
+}
+
+func main() {
+	flag.Parse()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/filter", func(w http.ResponseWriter, r *http.Request) {
+		processRequest(w, r, doFilter)
+	})
+	mux.HandleFunc("/score", func(w http.ResponseWriter, r *http.Request) {
+		processRequest(w, r, doScore)
+	})
+	mux.HandleFunc("/select", func(w http.ResponseWriter, r *http.Request) {
+		processRequest(w, r, doSelect)
+	})
+
+	log.Printf("Starting server on port %d", *port)
+	if err := http.ListenAndServe(fmt.Sprintf(":%d", *port), mux); err != nil {
+		if errors.Is(err, http.ErrServerClosed) {
+			log.Printf("Server shutdown")
+		} else {
+			log.Fatalf("Failed to start server: %v", err)
+		}
+	}
+}

--- a/pkg/controllers/scheduler/constants.go
+++ b/pkg/controllers/scheduler/constants.go
@@ -47,6 +47,7 @@ const (
 	EventReasonScheduleFederatedObject   = "ScheduleFederatedObject"
 	EventReasonInvalidFollowsObject      = "InvalidFollowsObject"
 	EventReasonWebhookConfigurationError = "WebhookConfigurationError"
+	EventReasonWebhookRegistered         = "WebhookRegistered"
 
 	SchedulingTriggerHashAnnotation = common.DefaultPrefix + "scheduling-trigger-hash"
 )

--- a/pkg/controllers/scheduler/core/generic_scheduler.go
+++ b/pkg/controllers/scheduler/core/generic_scheduler.go
@@ -95,7 +95,7 @@ func (g *genericScheduler) Schedule(
 	schedulingUnit framework.SchedulingUnit,
 	clusters []*fedcorev1a1.FederatedCluster,
 ) (result ScheduleResult, err error) {
-	klog.V(3).Infof("[scheduling] for %q try to schedule", schedulingUnit.Key())
+	logger := klog.FromContext(ctx)
 
 	// we do not reschedule if sticky cluster is enabled
 	if schedulingUnit.StickyCluster && len(schedulingUnit.CurrentClusters) > 0 {
@@ -105,30 +105,30 @@ func (g *genericScheduler) Schedule(
 
 	feasibleClusters, err := g.findClustersThatFitWorkload(ctx, fwk, schedulingUnit, clusters)
 	if err != nil {
-		return result, fmt.Errorf("[scheduling] failed to findClustersThatFitWorkload: %w", err)
+		return result, fmt.Errorf("failed to findClustersThatFitWorkload: %w", err)
 	}
-	klog.V(3).
-		Infof("[scheduling] for %q feasible clusters found: %s", schedulingUnit.Key(), spew.Sprint(feasibleClusters))
+	logger.V(2).
+		Info("Clusters filtered", "result", spew.Sprint(feasibleClusters))
 	if len(feasibleClusters) == 0 {
 		return result, nil
 	}
 
 	clusterScores, err := g.scoreClusters(ctx, fwk, schedulingUnit, feasibleClusters)
 	if err != nil {
-		return result, fmt.Errorf("[scheduling] failed to scoreClusters: %w", err)
+		return result, fmt.Errorf("failed to scoreClusters: %w", err)
 	}
-	klog.V(3).
-		Infof("[scheduling] for %q feasible clusters scores: %s", schedulingUnit.Key(), spew.Sprint(clusterScores))
+	logger.V(2).
+		Info("Clusters scored", "result", spew.Sprint(clusterScores))
 
 	selectedClusters, err := g.selectClusters(ctx, fwk, schedulingUnit, clusterScores)
 	if err != nil {
-		return result, fmt.Errorf("[scheduling] failed to selectClusters: %w", err)
+		return result, fmt.Errorf("failed to selectClusters: %w", err)
 	}
-	klog.V(3).Infof("[scheduling] for %q selected clusters: %s", schedulingUnit.Key(), spew.Sprint(selectedClusters))
+	logger.V(2).Info("Clusters selected", "clusters", spew.Sprint(selectedClusters))
 
 	// we skip replica scheduling if mode is Duplicate
 	if schedulingUnit.SchedulingMode == fedcorev1a1.SchedulingModeDuplicate {
-		klog.V(4).Infof("[scheduling] for %q Duplicate scheduling mode, skip replica scheduling", schedulingUnit.Key())
+		logger.V(3).Info("skip replica scheduling for Duplicate scheduling mode")
 		result.SuggestedClusters = make(map[string]*int64, len(selectedClusters))
 		for _, cluster := range selectedClusters {
 			result.SuggestedClusters[cluster.Name] = nil
@@ -138,10 +138,10 @@ func (g *genericScheduler) Schedule(
 
 	clusterReplicaList, err := g.replicaScheduling(ctx, fwk, schedulingUnit, selectedClusters)
 	if err != nil {
-		return result, fmt.Errorf("[scheduling] failed to replicaScheduling: %w", err)
+		return result, fmt.Errorf("failed to do replicaScheduling: %w", err)
 	}
-	klog.V(3).
-		Infof("[scheduling] for %q cluster replica list: %s", schedulingUnit.Key(), spew.Sprint(clusterReplicaList))
+	logger.V(2).
+		Info("Replicas assigned", "result", spew.Sprint(clusterReplicaList))
 	result.SuggestedClusters = make(map[string]*int64, len(clusterReplicaList))
 	for _, clusterReplica := range clusterReplicaList {
 		result.SuggestedClusters[clusterReplica.Cluster.Name] = pointer.Int64(clusterReplica.Replicas)
@@ -155,10 +155,12 @@ func (g *genericScheduler) findClustersThatFitWorkload(
 	schedulingUnit framework.SchedulingUnit,
 	clusters []*fedcorev1a1.FederatedCluster,
 ) ([]*fedcorev1a1.FederatedCluster, error) {
+	logger := klog.FromContext(ctx)
+
 	ret := make([]*fedcorev1a1.FederatedCluster, 0)
 	for _, cluster := range clusters {
 		if result := fwk.RunFilterPlugins(ctx, &schedulingUnit, cluster); !result.IsSuccess() {
-			klog.V(4).Infof("clusters %s doesn't fit, reason: %s", cluster.Name, result.AsError())
+			logger.V(2).Info("Cluster doesn't fit", "name", cluster.Name, "reason", result.AsError())
 		} else {
 			ret = append(ret, cluster)
 		}

--- a/pkg/controllers/scheduler/scheduler.go
+++ b/pkg/controllers/scheduler/scheduler.go
@@ -332,7 +332,7 @@ func (s *Scheduler) prepareToSchedule(
 					"object propagation policy %s not found",
 					policyKey.String(),
 				)
-				return nil, nil, nil, &worker.Result{Success: false, RequeueAfter: nil}
+				return nil, nil, nil, &worker.StatusAllOK
 			}
 			return nil, nil, nil, &worker.StatusError
 		}

--- a/pkg/controllers/scheduler/scheduler.go
+++ b/pkg/controllers/scheduler/scheduler.go
@@ -96,6 +96,7 @@ type Scheduler struct {
 }
 
 func NewScheduler(
+	logger klog.Logger,
 	typeConfig *fedcorev1a1.FederatedTypeConfig,
 	kubeClient kubeclient.Interface,
 	fedClient fedclient.Interface,
@@ -117,7 +118,7 @@ func NewScheduler(
 		fedClient:     fedClient,
 		dynamicClient: dynamicClient,
 		metrics:       metrics,
-		logger:        klog.LoggerWithName(klog.Background(), schedulerName),
+		logger:        logger.WithValues("controller", GlobalSchedulerName, "ftc", typeConfig.Name),
 	}
 
 	s.worker = worker.NewReconcileWorker(

--- a/pkg/controllers/scheduler/scheduler.go
+++ b/pkg/controllers/scheduler/scheduler.go
@@ -353,7 +353,7 @@ func (s *Scheduler) reconcile(qualifiedName common.QualifiedName) (status worker
 			policyKey.String(),
 		)
 
-		schedulingUnit, err := s.schedulingUnitForFedObject(fedObject, policy)
+		schedulingUnit, err := schedulingUnitForFedObject(s.typeConfig, fedObject, policy)
 		if err != nil {
 			keyedLogger.Error(err, "Failed to get scheduling unit")
 			s.eventRecorder.Eventf(

--- a/pkg/controllers/scheduler/scheduler.go
+++ b/pkg/controllers/scheduler/scheduler.go
@@ -389,7 +389,7 @@ func (s *Scheduler) reconcile(qualifiedName common.QualifiedName) (status worker
 			}
 		}
 
-		profile, err := s.createFramework(fedObject, schedulingProfile, s.buildFrameworkHandle())
+		framework, err := s.createFramework(schedulingProfile, s.buildFrameworkHandle())
 		if err != nil {
 			keyedLogger.Error(err, "Failed to construct scheduling profile")
 			s.eventRecorder.Eventf(
@@ -402,7 +402,7 @@ func (s *Scheduler) reconcile(qualifiedName common.QualifiedName) (status worker
 
 			return worker.StatusError
 		}
-		result, err = s.algorithm.Schedule(context.TODO(), profile, *schedulingUnit)
+		result, err = s.algorithm.Schedule(context.TODO(), framework, *schedulingUnit)
 		if err != nil {
 			keyedLogger.Error(err, "Failed to compute scheduling result")
 			s.eventRecorder.Eventf(

--- a/pkg/controllers/scheduler/scheduler.go
+++ b/pkg/controllers/scheduler/scheduler.go
@@ -533,6 +533,9 @@ func (s *Scheduler) persistSchedulingResult(
 		metav1.UpdateOptions{},
 	); err != nil {
 		keyedLogger.Error(err, "Failed to update federated object")
+		if apierrors.IsConflict(err) {
+			return worker.StatusConflict
+		}
 		s.eventRecorder.Eventf(
 			fedObject,
 			corev1.EventTypeWarning,
@@ -540,9 +543,6 @@ func (s *Scheduler) persistSchedulingResult(
 			"failed to schedule object: %v",
 			fmt.Errorf("failed to update federated object: %w", err),
 		)
-		if apierrors.IsConflict(err) {
-			return worker.StatusConflict
-		}
 		return worker.StatusError
 	}
 

--- a/pkg/controllers/scheduler/webhook.go
+++ b/pkg/controllers/scheduler/webhook.go
@@ -113,16 +113,16 @@ func makeTransport(config *fedcorev1a1.SchedulerPluginWebhookConfigurationSpec) 
 	return utilnet.SetTransportDefaults(&http.Transport{TLSClientConfig: tlsConfig}), nil
 }
 
-func (s *Scheduler) webhookPluginRegistry() runtime.Registry {
+func (s *Scheduler) webhookPluginRegistry() (runtime.Registry, error) {
 	registry := runtime.Registry{}
 
+	var err error
 	s.webhookPlugins.Range(func(name, plugin any) bool {
-		_ = registry.Register(name.(string), func(_ framework.Handle) (framework.Plugin, error) {
+		err = registry.Register(name.(string), func(_ framework.Handle) (framework.Plugin, error) {
 			return plugin.(framework.Plugin), nil
 		})
-
-		return true
+		return err == nil
 	})
 
-	return registry
+	return registry, err
 }

--- a/pkg/controllers/scheduler/webhook.go
+++ b/pkg/controllers/scheduler/webhook.go
@@ -40,6 +40,7 @@ var SchedulerSupportedPayloadVersions = sets.New(
 
 func (s *Scheduler) cacheWebhookPlugin(config *fedcorev1a1.SchedulerPluginWebhookConfiguration) {
 	logger := s.logger.WithValues("origin", "webhookEventHandler", "name", config.Name)
+	logger.V(1).Info("Initializing webhook plugin")
 
 	// Find the most preferred payload version that is supported by the scheduler.
 	var payloadVersion string
@@ -95,6 +96,14 @@ func (s *Scheduler) cacheWebhookPlugin(config *fedcorev1a1.SchedulerPluginWebhoo
 		return
 	}
 	s.webhookPlugins.Store(config.Name, plugin)
+	logger.V(1).Info("Webhook plugin registered")
+	s.eventRecorder.Eventf(
+		config,
+		corev1.EventTypeNormal,
+		EventReasonWebhookRegistered,
+		"Webhook plugin %q registered",
+		config.Name,
+	)
 }
 
 func makeTransport(config *fedcorev1a1.SchedulerPluginWebhookConfigurationSpec) (http.RoundTripper, error) {

--- a/pkg/controllers/scheduler/webhook.go
+++ b/pkg/controllers/scheduler/webhook.go
@@ -19,6 +19,7 @@ package scheduler
 import (
 	"fmt"
 	"net/http"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
@@ -77,9 +78,14 @@ func (s *Scheduler) cacheWebhookPlugin(config *fedcorev1a1.SchedulerPluginWebhoo
 		)
 		return
 	}
+
+	timeout := config.Spec.HTTPTimeout.Duration
+	if timeout == 0 {
+		timeout = 5 * time.Second
+	}
 	client := &http.Client{
 		Transport: transport,
-		Timeout:   config.Spec.HTTPTimeout.Duration,
+		Timeout:   timeout,
 	}
 
 	var plugin framework.Plugin

--- a/pkg/controllers/scheduler/webhook_test.go
+++ b/pkg/controllers/scheduler/webhook_test.go
@@ -1,0 +1,469 @@
+/*
+Copyright 2023 The KubeAdmiral Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"flag"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr/funcr"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	dynamicFake "k8s.io/client-go/dynamic/fake"
+	kubeFake "k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+	"k8s.io/klog/v2"
+
+	fedcorev1a1 "github.com/kubewharf/kubeadmiral/pkg/apis/core/v1alpha1"
+	schedwebhookv1a1 "github.com/kubewharf/kubeadmiral/pkg/apis/schedulerwebhook/v1alpha1"
+	fedtypesv1a1 "github.com/kubewharf/kubeadmiral/pkg/apis/types/v1alpha1"
+	fedFake "github.com/kubewharf/kubeadmiral/pkg/client/clientset/versioned/fake"
+	fedinformers "github.com/kubewharf/kubeadmiral/pkg/client/informers/externalversions"
+	"github.com/kubewharf/kubeadmiral/pkg/controllers/common"
+	"github.com/kubewharf/kubeadmiral/pkg/controllers/scheduler/framework"
+	"github.com/kubewharf/kubeadmiral/pkg/controllers/util/pendingcontrollers"
+	schemautil "github.com/kubewharf/kubeadmiral/pkg/controllers/util/schema"
+	"github.com/kubewharf/kubeadmiral/pkg/stats"
+)
+
+func init() {
+	// set klog version
+	klogFlags := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	klog.InitFlags(klogFlags)
+	if err := klogFlags.Set("v", "3"); err != nil {
+		panic(err)
+	}
+}
+
+// Generate a self-signed certificate and key pair.
+// DO NOT USE FOR PRODUCTION.
+// Ref: go's stdlib crypto/tls/generate_cert.go
+func generateCertAndKey(isClientCert bool, serverNames []string, ipAddresses []net.IP) ([]byte, []byte) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		panic(err)
+	}
+
+	notBefore := time.Unix(0, 0)
+	notAfter := notBefore.Add(100 * 365 * 24 * time.Hour)
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		panic(err)
+	}
+
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{"Acme Co"},
+		},
+		NotBefore: notBefore,
+		NotAfter:  notAfter,
+
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{},
+		BasicConstraintsValid: true,
+
+		DNSNames:    serverNames,
+		IPAddresses: ipAddresses,
+	}
+
+	if isClientCert {
+		template.ExtKeyUsage = append(template.ExtKeyUsage, x509.ExtKeyUsageClientAuth)
+	} else {
+		template.ExtKeyUsage = append(template.ExtKeyUsage, x509.ExtKeyUsageServerAuth)
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		panic(err)
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+
+	privBytes, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		panic(err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privBytes})
+
+	return certPEM, keyPEM
+}
+
+func getCluster(name string) *fedcorev1a1.FederatedCluster {
+	return &fedcorev1a1.FederatedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Status: fedcorev1a1.FederatedClusterStatus{
+			Conditions: []fedcorev1a1.ClusterCondition{
+				{
+					Type:   fedcorev1a1.ClusterJoined,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		},
+	}
+}
+
+/*
+This tests the following:
+
+- creating webhook plugins from SchedulerPluginWebhookConfiguration
+- resolving webhook plugins from SchedulingProfile
+- calling the webhook plugins
+*/
+func doTest(t *testing.T, clientTLS *fedcorev1a1.WebhookTLSConfig, serverTLS *tls.Config) {
+	t.Helper()
+	g := gomega.NewWithT(t)
+
+	var filterCalled atomic.Int32
+	mux := http.NewServeMux()
+	mux.Handle("/filter", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		filterCalled.Add(1)
+
+		req := schedwebhookv1a1.FilterRequest{}
+		err := json.NewDecoder(r.Body).Decode(&req)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		t.Logf("Received filter request for cluster %v", req.Cluster.Name)
+		response := schedwebhookv1a1.FilterResponse{
+			Selected: !strings.Contains(req.Cluster.Name, "reject"),
+			Error:    "",
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		err = json.NewEncoder(w).Encode(&response)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+	}))
+
+	server := httptest.NewUnstartedServer(mux)
+	if serverTLS != nil {
+		server.TLS = serverTLS.Clone()
+		server.StartTLS()
+	} else {
+		server.Start()
+	}
+	defer server.Close()
+
+	webhookConfig := fedcorev1a1.SchedulerPluginWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-webhook",
+		},
+		Spec: fedcorev1a1.SchedulerPluginWebhookConfigurationSpec{
+			PayloadVersions: []string{"v1alpha1"},
+			FilterPath:      "/filter",
+			HTTPTimeout:     metav1.Duration{Duration: 2 * time.Second},
+			URLPrefix:       server.URL,
+			TLSConfig:       clientTLS.DeepCopy(),
+		},
+	}
+
+	// only enable webhook plugin
+	profile := fedcorev1a1.SchedulingProfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "webhook-only",
+		},
+		Spec: fedcorev1a1.SchedulingProfileSpec{
+			Plugins: &fedcorev1a1.Plugins{
+				Filter: fedcorev1a1.PluginSet{
+					Enabled: []fedcorev1a1.Plugin{
+						{
+							Type: "Webhook",
+							Name: "test-webhook",
+						},
+					},
+					Disabled: []fedcorev1a1.Plugin{
+						{Name: "*"},
+					},
+				},
+				Score: fedcorev1a1.PluginSet{
+					Disabled: []fedcorev1a1.Plugin{
+						{Name: "*"},
+					},
+				},
+				Select: fedcorev1a1.PluginSet{
+					Disabled: []fedcorev1a1.Plugin{
+						{Name: "*"},
+					},
+				},
+			},
+		},
+	}
+
+	policy := fedcorev1a1.PropagationPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "webhook-policy",
+		},
+		Spec: fedcorev1a1.PropagationPolicySpec{
+			SchedulingProfile: "webhook-only",
+			SchedulingMode:    fedcorev1a1.SchedulingModeDuplicate,
+		},
+	}
+
+	typeConfig := &fedcorev1a1.FederatedTypeConfig{
+		Spec: fedcorev1a1.FederatedTypeConfigSpec{
+			FederatedType: fedcorev1a1.APIResource{
+				Group:      fedtypesv1a1.SchemeGroupVersion.Group,
+				Version:    fedcorev1a1.SchemeGroupVersion.Version,
+				Kind:       "FederatedDeployment",
+				PluralName: "federateddeployments",
+				Scope:      "Namespaced",
+			},
+			TargetType: fedcorev1a1.APIResource{
+				Group:      "apps",
+				Version:    "v1",
+				Kind:       "Deployment",
+				PluralName: "deployments",
+				Scope:      "Namespaced",
+			},
+			PathDefinition: fedcorev1a1.PathDefinition{
+				ReplicasSpec: "spec.replicas",
+			},
+		},
+	}
+
+	clusters := []runtime.Object{
+		getCluster("accept"),
+		getCluster("reject"),
+	}
+
+	kubeClient := kubeFake.NewSimpleClientset()
+
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypeWithName(
+		fedtypesv1a1.SchemeGroupVersion.WithKind(typeConfig.Spec.FederatedType.Kind+"List"),
+		&unstructured.UnstructuredList{},
+	)
+
+	// Ensure watcher is started before creating objects to avoid missing events occurred after LIST and before WATCH
+	// ref: https://github.com/kubernetes/client-go/blob/master/examples/fake-client/main_test.go
+	watcherStarted := make(chan struct{})
+	dynamicClient := dynamicFake.NewSimpleDynamicClient(scheme)
+	dynamicClient.PrependWatchReactor("*", func(action clienttesting.Action) (handled bool, ret watch.Interface, err error) {
+		gvr := action.GetResource()
+		ns := action.GetNamespace()
+		watch, err := dynamicClient.Tracker().Watch(gvr, ns)
+		if err != nil {
+			return false, nil, err
+		}
+		close(watcherStarted)
+		return true, watch, nil
+	})
+	dynInformerFactory := dynamicinformer.NewDynamicSharedInformerFactory(dynamicClient, 0)
+
+	fedClient := fedFake.NewSimpleClientset(append(clusters, &webhookConfig, &profile, &policy)...)
+	fedInformerFactory := fedinformers.NewSharedInformerFactory(fedClient, 0)
+
+	federatedType := typeConfig.GetFederatedType()
+	gvr := schemautil.APIResourceToGVR(&federatedType)
+	scheduler, err := NewScheduler(
+		typeConfig, kubeClient, fedClient, dynamicClient,
+		dynInformerFactory.ForResource(gvr),
+		fedInformerFactory.Core().V1alpha1().PropagationPolicies(),
+		fedInformerFactory.Core().V1alpha1().ClusterPropagationPolicies(),
+		fedInformerFactory.Core().V1alpha1().FederatedClusters(),
+		fedInformerFactory.Core().V1alpha1().SchedulingProfiles(),
+		fedInformerFactory.Core().V1alpha1().SchedulerPluginWebhookConfigurations(),
+		stats.NewMock("test", "kube-admiral", false),
+		1,
+	)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	ctx := klog.NewContext(context.Background(), funcr.New(func(prefix, args string) {
+		// let klog write to the test logger
+		t.Logf("%s\n", args)
+	}, funcr.Options{}))
+
+	dynInformerFactory.Start(ctx.Done())
+	fedInformerFactory.Start(ctx.Done())
+
+	go scheduler.Run(ctx)
+
+	dynInformerFactory.WaitForCacheSync(ctx.Done())
+	fedInformerFactory.WaitForCacheSync(ctx.Done())
+
+	<-watcherStarted
+
+	// Wait for the plugin to be initialized
+	g.Eventually(func(g gomega.Gomega) {
+		plugin, exists := scheduler.webhookPlugins.Load(webhookConfig.Name)
+		g.Expect(exists).To(gomega.BeTrue())
+		g.Expect(plugin.(framework.Plugin).Name()).To(gomega.Equal(webhookConfig.Name))
+	}).WithContext(ctx).WithTimeout(3 * time.Second).WithPolling(100 * time.Millisecond).Should(gomega.Succeed())
+
+	fedObj := metav1.PartialObjectMetadata{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: fedtypesv1a1.SchemeGroupVersion.String(),
+			Kind:       "FederatedDeployment",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+			Labels: map[string]string{
+				PropagationPolicyNameLabel: policy.Name,
+			},
+			Annotations: map[string]string{
+				pendingcontrollers.PendingControllersAnnotation: "[]",
+			},
+		},
+	}
+
+	fedObjUns := &unstructured.Unstructured{}
+	fedObjUns.Object, err = runtime.DefaultUnstructuredConverter.ToUnstructured(&fedObj)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	err = unstructured.SetNestedMap(fedObjUns.Object, map[string]interface{}{}, common.TemplatePath...)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	fedObjUns, err = dynamicClient.Resource(gvr).Namespace(fedObj.Namespace).Create(ctx, fedObjUns, metav1.CreateOptions{})
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	g.Eventually(func(g gomega.Gomega) {
+		fedObjUns, err = dynamicClient.Resource(gvr).Namespace(fedObj.Namespace).Get(ctx, fedObj.Name, metav1.GetOptions{})
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		fedObj := fedtypesv1a1.GenericObjectWithPlacements{}
+		err = runtime.DefaultUnstructuredConverter.FromUnstructured(fedObjUns.Object, &fedObj)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		g.Expect(fedObj.ClusterNameUnion()).To(gomega.Equal(map[string]struct{}{"accept": {}}))
+	}).WithContext(ctx).WithTimeout(3 * time.Second).WithPolling(100 * time.Millisecond).Should(gomega.Succeed())
+
+	g.Expect(filterCalled.Load()).To(gomega.Equal(int32(len(clusters))))
+}
+
+func TestSchedulerWebhook(t *testing.T) {
+	type testCase struct {
+		clientConfig *fedcorev1a1.WebhookTLSConfig
+		serverConfig *tls.Config
+	}
+
+	g := gomega.NewWithT(t)
+
+	localHostCert, localHostKey := generateCertAndKey(false, nil, []net.IP{net.IPv4(127, 0, 0, 1)})
+	exampleComHost := "example.com"
+	exampleComHostCert, exampleComHostKey := generateCertAndKey(false, []string{exampleComHost}, nil)
+
+	clientCert, clientKey := generateCertAndKey(true, nil, nil)
+
+	testCases := map[string]testCase{
+		"no TLS": {
+			// neither party uses TLS and communicates with each other over plain TCP
+		},
+		"only server uses TLS but client skips verification": {
+			clientConfig: &fedcorev1a1.WebhookTLSConfig{
+				Insecure: true,
+			},
+			// Pass empty non-nil tls.Config to default to httptest server's internal TLS config
+			serverConfig: &tls.Config{MinVersion: tls.VersionTLS12},
+		},
+		"only server uses TLS": func() testCase {
+			serverCert, serverKey := localHostCert, localHostKey
+
+			clientConfig := &fedcorev1a1.WebhookTLSConfig{
+				Insecure: false,
+				CAData:   serverCert,
+			}
+
+			tlsCert, err := tls.X509KeyPair(serverCert, serverKey)
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+
+			serverConfig := &tls.Config{
+				MinVersion:   tls.VersionTLS12,
+				Certificates: []tls.Certificate{tlsCert},
+			}
+
+			return testCase{clientConfig: clientConfig, serverConfig: serverConfig}
+		}(),
+		"only server uses TLS but with different name in certificate": func() testCase {
+			serverCert, serverKey := exampleComHostCert, exampleComHostKey
+
+			clientConfig := &fedcorev1a1.WebhookTLSConfig{
+				Insecure:   false,
+				ServerName: exampleComHost,
+				CAData:     serverCert,
+			}
+
+			tlsCert, err := tls.X509KeyPair(serverCert, serverKey)
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+
+			serverConfig := &tls.Config{
+				MinVersion:   tls.VersionTLS12,
+				Certificates: []tls.Certificate{tlsCert},
+			}
+
+			return testCase{clientConfig: clientConfig, serverConfig: serverConfig}
+		}(),
+		"mutual TLS": func() testCase {
+			serverCert, serverKey := localHostCert, localHostKey
+			clientCert, clientKey := clientCert, clientKey
+
+			clientConfig := &fedcorev1a1.WebhookTLSConfig{
+				Insecure: false,
+				CertData: clientCert,
+				KeyData:  clientKey,
+				CAData:   serverCert,
+			}
+
+			tlsCert, err := tls.X509KeyPair(serverCert, serverKey)
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+
+			clientCAs := x509.NewCertPool()
+			ok := clientCAs.AppendCertsFromPEM(clientCert)
+			g.Expect(ok).To(gomega.BeTrue())
+
+			serverConfig := &tls.Config{
+				MinVersion:   tls.VersionTLS12,
+				Certificates: []tls.Certificate{tlsCert},
+				// require client authentication
+				ClientAuth: tls.RequireAndVerifyClientCert,
+				// server should trust the client cert
+				ClientCAs: clientCAs,
+			}
+
+			return testCase{clientConfig: clientConfig, serverConfig: serverConfig}
+		}(),
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			doTest(t, tc.clientConfig, tc.serverConfig)
+		})
+	}
+}

--- a/test/e2e/automigration/automigration.go
+++ b/test/e2e/automigration/automigration.go
@@ -18,6 +18,7 @@ package automigration
 
 import (
 	"context"
+	"sort"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
@@ -45,7 +46,7 @@ var (
 
 	resourcePropagationTimeout = 10 * time.Second
 	replicasReadyTimeout       = 30 * time.Second
-	autoMigrationTimeout       = 30 * time.Second
+	autoMigrationTimeout       = 50 * time.Second
 )
 
 var _ = ginkgo.Describe("auto migration", autoMigrationTestLabel, func() {
@@ -68,7 +69,10 @@ var _ = ginkgo.Describe("auto migration", autoMigrationTestLabel, func() {
 			gomega.Expect(len(candidateClustes)).To(gomega.BeNumerically(">=", 3), "At least 3 clusters are required for this test")
 
 			clusters = candidateClustes[:3]
-			clusterToMigrateFrom = candidateClustes[0]
+			sort.Slice(clusters, func(i, j int) bool {
+				return clusters[i].Name < clusters[j].Name
+			})
+			clusterToMigrateFrom = clusters[0]
 		})
 
 		propPolicy := policies.PropagationPolicyForClustersWithPlacements(f.Name(), clusters)


### PR DESCRIPTION
Notable changes:

Features:
- Allow webhook plugins to be referenced and used by `SchedulerProfile` (with integration tests)
- webhook plugins now handle non-200 responses correctly (with unit tests)

Fixes:
- extract workload template correctly when creating scheduling unit (with unit tests)

Refactors:
- split scheduler's `reconcile` function into smaller functions
- standardise logging in `generic_scheduler.go`
- scheduling `Algorithm` no longer holds a reference to cluster store; clusters are passed explicitly into `Schedule`

Docs:
- Add sample scheduler webhook