### PR TITLE
fix: removal of unjoined cluster should not hang

### DIFF
--- a/config/crds/core.kubeadmiral.io_federatedclusters.yaml
+++ b/config/crds/core.kubeadmiral.io_federatedclusters.yaml
@@ -98,6 +98,7 @@ spec:
                 type: boolean
             required:
             - apiEndpoint
+            - secretRef
             type: object
           status:
             description: FederatedClusterStatus defines the observed state of FederatedCluster
@@ -150,10 +151,11 @@ spec:
                       type: string
                     message:
                       description: Human readable message indicating details about
-                        last transition.
+                        the current status.
                       type: string
                     reason:
-                      description: (brief) reason for the condition's last transition.
+                      description: Programmatic identifier indicating the reason for
+                        the current status.
                       type: string
                     status:
                       description: Status of the condition, one of True, False, Unknown.
@@ -163,10 +165,16 @@ spec:
                       type: string
                   required:
                   - lastProbeTime
+                  - lastTransitionTime
+                  - message
+                  - reason
                   - status
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               resources:
                 description: Resources describes the cluster's resources.
                 properties:
@@ -196,8 +204,6 @@ spec:
                     format: int64
                     type: integer
                 type: object
-            required:
-            - conditions
             type: object
         type: object
     served: true

--- a/config/crds/core.kubeadmiral.io_federatedclusters.yaml
+++ b/config/crds/core.kubeadmiral.io_federatedclusters.yaml
@@ -175,6 +175,11 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              joinPerformed:
+                description: Whether any effectual action was performed in the cluster
+                  while joining. If true, clean-up is required on cluster removal
+                  to undo the side-effects.
+                type: boolean
               resources:
                 description: Resources describes the cluster's resources.
                 properties:

--- a/pkg/apis/core/v1alpha1/types_federatedcluster.go
+++ b/pkg/apis/core/v1alpha1/types_federatedcluster.go
@@ -89,6 +89,10 @@ type FederatedClusterStatus struct {
 	// The list of api resource types defined in the federated cluster
 	// +optional
 	APIResourceTypes []APIResource `json:"apiResourceTypes,omitempty"`
+	// Whether any effectual action was performed in the cluster while joining.
+	// If true, clean-up is required on cluster removal to undo the side-effects.
+	// +optional
+	JoinPerformed bool `json:"joinPerformed,omitempty"`
 }
 
 // LocalSecretReference is a reference to a secret within the enclosing namespace.

--- a/pkg/apis/core/v1alpha1/types_federatedcluster.go
+++ b/pkg/apis/core/v1alpha1/types_federatedcluster.go
@@ -28,7 +28,7 @@ import (
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +k8s:openapi-gen=true
+// +kubebuilder:validation:Required
 // +kubebuilder:resource:path=federatedclusters,shortName=fcluster,scope=Cluster
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name=ready,type=string,JSONPath=.status.conditions[?(@.type=='Ready')].status
@@ -60,6 +60,7 @@ type FederatedClusterSpec struct {
 	APIEndpoint string `json:"apiEndpoint"`
 
 	// Access API endpoint with security.
+	// +optional
 	Insecure bool `json:"insecure,omitempty"`
 
 	// Whether to use service account token to authenticate to the member cluster.
@@ -68,7 +69,6 @@ type FederatedClusterSpec struct {
 
 	// Name of the secret containing the token required to access the member cluster.
 	// The secret needs to exist in the fed system namespace.
-	// +optional
 	SecretRef LocalSecretReference `json:"secretRef"`
 
 	// If specified, the cluster's taints.
@@ -79,7 +79,10 @@ type FederatedClusterSpec struct {
 // FederatedClusterStatus defines the observed state of FederatedCluster
 type FederatedClusterStatus struct {
 	// Conditions is an array of current cluster conditions.
-	Conditions []ClusterCondition `json:"conditions"`
+	// +optional
+	// +listType=map
+	// +listMapKey=type
+	Conditions []ClusterCondition `json:"conditions,omitempty"`
 	// Resources describes the cluster's resources.
 	// +optional
 	Resources Resources `json:"resources,omitempty"`
@@ -103,14 +106,11 @@ type ClusterCondition struct {
 	// Last time the condition was checked.
 	LastProbeTime metav1.Time `json:"lastProbeTime"`
 	// Last time the condition transit from one status to another.
-	// +optional
-	LastTransitionTime *metav1.Time `json:"lastTransitionTime,omitempty"`
-	// (brief) reason for the condition's last transition.
-	// +optional
-	Reason *string `json:"reason,omitempty"`
-	// Human readable message indicating details about last transition.
-	// +optional
-	Message *string `json:"message,omitempty"`
+	LastTransitionTime metav1.Time `json:"lastTransitionTime"`
+	// Programmatic identifier indicating the reason for the current status.
+	Reason string `json:"reason"`
+	// Human readable message indicating details about the current status.
+	Message string `json:"message"`
 }
 
 type ClusterConditionType string

--- a/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
@@ -85,20 +85,7 @@ func (in *AutoMigrationTrigger) DeepCopy() *AutoMigrationTrigger {
 func (in *ClusterCondition) DeepCopyInto(out *ClusterCondition) {
 	*out = *in
 	in.LastProbeTime.DeepCopyInto(&out.LastProbeTime)
-	if in.LastTransitionTime != nil {
-		in, out := &in.LastTransitionTime, &out.LastTransitionTime
-		*out = (*in).DeepCopy()
-	}
-	if in.Reason != nil {
-		in, out := &in.Reason, &out.Reason
-		*out = new(string)
-		**out = **in
-	}
-	if in.Message != nil {
-		in, out := &in.Message, &out.Message
-		*out = new(string)
-		**out = **in
-	}
+	in.LastTransitionTime.DeepCopyInto(&out.LastTransitionTime)
 	return
 }
 

--- a/pkg/controllers/federatedcluster/clusterstatus.go
+++ b/pkg/controllers/federatedcluster/clusterstatus.go
@@ -66,9 +66,8 @@ func collectIndividualClusterStatus(
 	cluster *fedcorev1a1.FederatedCluster,
 	fedClient fedclient.Interface,
 	federatedClient federatedclient.FederatedClientFactory,
-	logger klog.Logger,
 ) error {
-	logger = logger.WithValues("sub-process", "status-collection")
+	logger := klog.FromContext(ctx)
 
 	clusterKubeClient, exists, err := federatedClient.KubeClientsetForCluster(cluster.Name)
 	if !exists {

--- a/pkg/controllers/federatedcluster/controller.go
+++ b/pkg/controllers/federatedcluster/controller.go
@@ -342,9 +342,7 @@ func handleTerminatingCluster(
 	// 1. when the cluster has no ClusterJoin condition (the cluster did not even make it past the first join step)
 	// 2. when the cluster is Unjoinable (it was already part of another federation)
 	joinedCondition := getClusterCondition(&cluster.Status, fedcorev1a1.ClusterJoined)
-	if joinedCondition == nil {
-		requireCleanup = false
-	} else if joinedCondition.Reason != nil && *joinedCondition.Reason == ClusterUnjoinableReason {
+	if joinedCondition == nil || joinedCondition.Reason == ClusterUnjoinableReason {
 		requireCleanup = false
 	}
 

--- a/pkg/controllers/federatedcluster/util.go
+++ b/pkg/controllers/federatedcluster/util.go
@@ -57,7 +57,7 @@ func getNewClusterOfflineCondition(
 	condition := fedcorev1a1.ClusterCondition{
 		Type:               fedcorev1a1.ClusterOffline,
 		LastProbeTime:      conditionTime,
-		LastTransitionTime: &conditionTime,
+		LastTransitionTime: conditionTime,
 	}
 
 	var reason, message string
@@ -70,8 +70,8 @@ func getNewClusterOfflineCondition(
 	}
 
 	condition.Status = status
-	condition.Reason = &reason
-	condition.Message = &message
+	condition.Reason = reason
+	condition.Message = message
 
 	return condition
 }
@@ -84,10 +84,10 @@ func getNewClusterReadyCondition(
 	condition := fedcorev1a1.ClusterCondition{
 		Type:               fedcorev1a1.ClusterReady,
 		Status:             status,
-		Reason:             &reason,
-		Message:            &message,
+		Reason:             reason,
+		Message:            message,
 		LastProbeTime:      conditionTime,
-		LastTransitionTime: &conditionTime,
+		LastTransitionTime: conditionTime,
 	}
 
 	return condition
@@ -102,11 +102,8 @@ func isClusterJoined(status *fedcorev1a1.FederatedClusterStatus) (joined, failed
 		return true, false
 	}
 
-	if joinedCondition.Reason == nil {
-		return false, false
-	}
-	if *joinedCondition.Reason == JoinTimeoutExceededReason ||
-		*joinedCondition.Reason == ClusterUnjoinableReason {
+	if joinedCondition.Reason == JoinTimeoutExceededReason ||
+		joinedCondition.Reason == ClusterUnjoinableReason {
 		return false, true
 	}
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -21,18 +21,28 @@ package e2e
 import (
 	"testing"
 
+	"github.com/go-logr/logr/funcr"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 
 	// Remember to import the package for tests to be discovered by ginkgo
+	// _ "github.com/kubewharf/kubeadmiral/test/e2e/example"
+
 	_ "github.com/kubewharf/kubeadmiral/test/e2e/automigration"
 	_ "github.com/kubewharf/kubeadmiral/test/e2e/federatedcluster"
 	_ "github.com/kubewharf/kubeadmiral/test/e2e/resourcepropagation"
 	_ "github.com/kubewharf/kubeadmiral/test/e2e/schedulingprofile"
-	// _ "github.com/kubewharf/kubeadmiral/test/e2e/example"
 )
 
 func TestMain(t *testing.T) {
+	// replace the default GinkgoLogr for better formatting
+	ginkgo.GinkgoLogr = funcr.New(func(prefix, args string) {
+		if len(prefix) > 0 {
+			prefix = prefix + ": "
+		}
+		ginkgo.GinkgoWriter.Printf("%s%s\n", prefix, args)
+	}, funcr.Options{})
+
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	ginkgo.RunSpecs(t, "KubeAdmiral E2E Tests")
 }

--- a/test/e2e/framework/cluster/cluster.go
+++ b/test/e2e/framework/cluster/cluster.go
@@ -28,31 +28,31 @@ import (
 func ClusterJoined(cluster *fedcorev1a1.FederatedCluster) bool {
 	cond := GetClusterJoinCondition(cluster.Status.Conditions)
 	return cond != nil && cond.Status == corev1.ConditionTrue &&
-		cond.Reason != nil && *cond.Reason == federatedcluster.ClusterJoinedReason &&
-		cond.Message != nil && *cond.Message == federatedcluster.ClusterJoinedMessage
+		cond.Reason == federatedcluster.ClusterJoinedReason &&
+		cond.Message == federatedcluster.ClusterJoinedMessage
 }
 
 func ClusterReady(cluster *fedcorev1a1.FederatedCluster) bool {
 	cond := GetClusterReadyCondition(cluster.Status.Conditions)
 	return cond != nil && cond.Status == corev1.ConditionTrue &&
-		cond.Reason != nil && *cond.Reason == federatedcluster.ClusterReadyReason &&
-		cond.Message != nil && *cond.Message == federatedcluster.ClusterReadyMessage
+		cond.Reason == federatedcluster.ClusterReadyReason &&
+		cond.Message == federatedcluster.ClusterReadyMessage
 }
 
 func ClusterTimedOut(cluster *fedcorev1a1.FederatedCluster) bool {
 	cond := GetClusterJoinCondition(cluster.Status.Conditions)
 	messagePrefix := strings.TrimSuffix(federatedcluster.JoinTimeoutExceededMessageTemplate, "%v")
 	return cond != nil && cond.Status == corev1.ConditionFalse &&
-		cond.Reason != nil && *cond.Reason == federatedcluster.JoinTimeoutExceededReason &&
-		cond.Message != nil && strings.HasPrefix(*cond.Message, messagePrefix)
+		cond.Reason == federatedcluster.JoinTimeoutExceededReason &&
+		strings.HasPrefix(cond.Message, messagePrefix)
 }
 
 func ClusterReachable(cluster *fedcorev1a1.FederatedCluster) bool {
 	cond := GetClusterOfflineCondition(cluster.Status.Conditions)
 	return ClusterJoined(cluster) && ClusterReady(cluster) &&
 		cond != nil && cond.Status == corev1.ConditionFalse &&
-		cond.Reason != nil && *cond.Reason == federatedcluster.ClusterReachableReason &&
-		cond.Message != nil && *cond.Message == federatedcluster.ClusterReachableMsg
+		cond.Reason == federatedcluster.ClusterReachableReason &&
+		cond.Message == federatedcluster.ClusterReachableMsg
 }
 
 func ClusterUnreachable(cluster *fedcorev1a1.FederatedCluster) bool {
@@ -63,11 +63,11 @@ func ClusterUnreachable(cluster *fedcorev1a1.FederatedCluster) bool {
 
 	return ClusterJoined(cluster) &&
 		readyCond != nil && readyCond.Status == corev1.ConditionUnknown &&
-		readyCond.Reason != nil && *readyCond.Reason == federatedcluster.ClusterNotReachableReason &&
-		readyCond.Message != nil && *readyCond.Message == federatedcluster.ClusterNotReachableMsg &&
+		readyCond.Reason == federatedcluster.ClusterNotReachableReason &&
+		readyCond.Message == federatedcluster.ClusterNotReachableMsg &&
 		offlineCond != nil && offlineCond.Status == corev1.ConditionTrue &&
-		offlineCond.Reason != nil && *offlineCond.Reason == federatedcluster.ClusterNotReachableReason &&
-		offlineCond.Message != nil && *offlineCond.Message == federatedcluster.ClusterNotReachableMsg
+		offlineCond.Reason == federatedcluster.ClusterNotReachableReason &&
+		offlineCond.Message == federatedcluster.ClusterNotReachableMsg
 }
 
 func GetClusterJoinCondition(conditions []fedcorev1a1.ClusterCondition) *fedcorev1a1.ClusterCondition {


### PR DESCRIPTION
Main contribution:
* Cluster that failed to join due to reachability issues will not be blocked for clean-up upon deletion
This is achieved by recording whether any effectual action was performed during joining in a new status field `JoinPerformed`. Upon deletion, we only require clean-up if `JoinPerformed` is true.
Note: a cluster that failed to join but underwent partial joining process (e.g. namespace created but rbac not created) will still require clean-up.

Other contributions:
* Refactor `FederatedCluster` API types:
  * secretRef is no longer required
  * lastTransitionTimestamp, reason, message in conditions are now value types and required
  * disallow conditions with duplicate types
  * make conditions optional
  * reword message and reason description
* Standardise contextual logging in cluster join code
* Replace the default `GinkgoLogr` to tidy up the e2e logs


