### PR TITLE
fix: federating invalid templates

### DIFF
--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/kubewharf/kubeadmiral/cmd/controller-manager/app"
 	"github.com/kubewharf/kubeadmiral/cmd/controller-manager/app/options"
-	"github.com/kubewharf/kubeadmiral/pkg/controllermanager/signals"
+	"github.com/kubewharf/kubeadmiral/pkg/util/signals"
 )
 
 func main() {
@@ -40,10 +40,7 @@ func main() {
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())
-	go func() {
-		<-signals.SetupSignalHandler()
-		cancel()
-	}()
+	signals.SetupSignalHandler(cancel)
 
 	app.Run(ctx, opts)
 }

--- a/pkg/controllers/status/controller.go
+++ b/pkg/controllers/status/controller.go
@@ -563,9 +563,18 @@ func (s *KubeFedStatusController) latestReplicasetDigests(
 		if len(errs) == 0 {
 			digests = append(digests, digest)
 		} else {
-			for _, err := range errs {
-				runtime.HandleError(err)
+			errList := make([]string, len(errs))
+			for i := range errs {
+				errList[i] = errs[i].Error()
 			}
+			// use a higher log level since replicaset digests are currently not a supported feature
+			klog.V(4).Info(
+				"Failed to get replicaset digest from member object %s %q from cluster %q: %v",
+				targetKind,
+				key,
+				clusterName,
+				strings.Join(errList, ","),
+			)
 		}
 	}
 

--- a/pkg/controllers/util/clusterutil.go
+++ b/pkg/controllers/util/clusterutil.go
@@ -200,5 +200,6 @@ func BuildClusterConfigWithGenericClient(
 	if err != nil {
 		return nil, fmt.Errorf("cannot build rest config from cluster secret: %w", err)
 	}
+
 	return clusterConfig, nil
 }

--- a/pkg/controllers/util/genericinformer.go
+++ b/pkg/controllers/util/genericinformer.go
@@ -93,7 +93,7 @@ func NewGenericInformerWithEventHandler(
 	if err != nil {
 		return nil, nil, err
 	}
-	klog.Infof("New informer for gvk: %+v", gvk)
+	klog.V(4).Infof("New informer for gvk: %+v", gvk)
 	store, controller := cache.NewInformer(
 		&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (pkgruntime.Object, error) {

--- a/pkg/controllers/util/worker/constants.go
+++ b/pkg/controllers/util/worker/constants.go
@@ -62,4 +62,7 @@ var (
 	// StatusConflict indicates that reconciliation could not be completed due to a conflict
 	// (e.g., AlreadyExists or Conflict), and the object should be requeued with a small delay.
 	StatusConflict = Result{Success: false, RequeueAfter: pointer.Duration(500 * time.Millisecond), Backoff: false}
+	// StatusErrorNoRetry indicates that the reconciliation could not be completed due to an error, but the object
+	// should not be reenqueued.
+	StatusErrorNoRetry = Result{Success: false, RequeueAfter: nil, Backoff: false}
 )

--- a/test/e2e/framework/resources/resources.go
+++ b/test/e2e/framework/resources/resources.go
@@ -81,8 +81,9 @@ func GetSimpleDeployment(baseName string) *appsv1.Deployment {
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Name:  "main",
-							Image: DefaultPodImage,
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							Name:            "main",
+							Image:           DefaultPodImage,
 						},
 					},
 				},
@@ -128,9 +129,10 @@ func GetSimpleJob(baseName string) *batchv1.Job {
 					RestartPolicy: corev1.RestartPolicyNever,
 					Containers: []corev1.Container{
 						{
-							Name:    "main",
-							Image:   DefaultPodImage,
-							Command: []string{"sleep", "2"},
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							Name:            "main",
+							Image:           DefaultPodImage,
+							Command:         []string{"sleep", "2"},
 						},
 					},
 				},
@@ -207,9 +209,10 @@ func GetSimpleV1Beta1CronJob(baseName string) *batchv1b1.CronJob {
 							RestartPolicy: corev1.RestartPolicyNever,
 							Containers: []corev1.Container{
 								{
-									Name:    "main",
-									Image:   DefaultPodImage,
-									Command: []string{"sleep", "2"},
+									ImagePullPolicy: corev1.PullIfNotPresent,
+									Name:            "main",
+									Image:           DefaultPodImage,
+									Command:         []string{"sleep", "2"},
 								},
 							},
 						},


### PR DESCRIPTION
This pr stops the federate controller from retrying after an `Invalid` error is returned on creation. This is because the federated object template will continue to be invalid until there is an update to the source object. Thus, there is no point in retrying after receiving this error.

In addition:

1. Signal handler is refactored for clarity and to avoid the use of a global channel
2. Log level is increased for some unimportant logs
3. `pullIfNotPresent` policy is used for e2e container images to speed up tests