### PR TITLE
feat(retain): enhance label propagation

### DIFF
--- a/pkg/controllers/common/constants.go
+++ b/pkg/controllers/common/constants.go
@@ -129,6 +129,14 @@ const (
 	AutoMigrationInfoAnnotation = DefaultPrefix + "auto-migration-info"
 )
 
+// TemplateAnnotationKeys and TemplateLabelKeys are used to store the keys of annotations and labels that are present
+// on the resource template. By persisting these, we can tell whether an annotation/label is deleted from the template
+// and prevent accidental retention.
+const (
+	TemplateAnnotationKeys = DefaultPrefix + "template-annotation-keys"
+	TemplateLabelKeys      = DefaultPrefix + "template-label-keys"
+)
+
 // The following consts are keys used to store information in the federated cluster secret
 
 const (

--- a/pkg/controllers/sync/dispatch/retain.go
+++ b/pkg/controllers/sync/dispatch/retain.go
@@ -64,15 +64,8 @@ func RetainOrMergeClusterFields(
 	// controllers in a member cluster.  It is still possible to set the fields
 	// via overrides.
 	desiredObj.SetFinalizers(clusterObj.GetFinalizers())
-	mergedAnnotations := mergeAnnotations(desiredObj.GetAnnotations(), clusterObj.GetAnnotations())
-	// Propagate the removal of special annotations.
-	templateAnnotations := desiredObj.GetAnnotations()
-	for key := range RemovalRespectedAnnotations {
-		if _, ok := templateAnnotations[key]; !ok {
-			delete(mergedAnnotations, key)
-		}
-	}
-	desiredObj.SetAnnotations(mergedAnnotations)
+	mergeAnnotations(desiredObj, clusterObj)
+	mergeLabels(desiredObj, clusterObj)
 
 	switch {
 	case schemautil.IsServiceGvk(targetGvk):
@@ -110,19 +103,38 @@ func RetainOrMergeClusterFields(
 	return nil
 }
 
-// mergeAnnotations merges annotations from template and cluster object.
-// Annotations from clusterAnnotations are copied into templateAnnotations.
-// For the same key in these two maps, value from template is preserved.
-func mergeAnnotations(templateAnnotations, clusterAnnotations map[string]string) map[string]string {
-	if templateAnnotations == nil {
-		return clusterAnnotations
+func mergeAnnotations(desiredObj, clusterObj *unstructured.Unstructured) {
+	mergedAnnotations := mergeStringMaps(
+		desiredObj.GetAnnotations(),
+		clusterObj.GetAnnotations(),
+	)
+	desiredObj.SetAnnotations(mergedAnnotations)
+}
+
+func mergeLabels(desiredObj, clusterObj *unstructured.Unstructured) {
+	mergedLabels := mergeStringMaps(
+		desiredObj.GetLabels(),
+		clusterObj.GetLabels(),
+	)
+	desiredObj.SetLabels(mergedLabels)
+}
+
+// mergeStringMaps merges string maps (e.g. annotations or labels) from template and observed cluster objects.
+// For the same key in these two maps, value from templateMap takes precedence.
+func mergeStringMaps(
+	templateMap, observedMap map[string]string,
+) map[string]string {
+	if templateMap == nil {
+		templateMap = make(map[string]string, len(observedMap))
 	}
-	for k, v := range clusterAnnotations {
-		if _, ok := templateAnnotations[k]; !ok {
-			templateAnnotations[k] = v
+
+	for k, v := range observedMap {
+		if _, ok := templateMap[k]; !ok {
+			templateMap[k] = v
 		}
 	}
-	return templateAnnotations
+
+	return templateMap
 }
 
 func retainServiceFields(desiredObj, clusterObj *unstructured.Unstructured) error {

--- a/pkg/controllers/sync/resource.go
+++ b/pkg/controllers/sync/resource.go
@@ -197,6 +197,21 @@ func (r *federatedResource) ObjectForCluster(clusterName string) (*unstructured.
 		obj.SetFinalizers(nil)
 	}
 
+	// Record the annotation/label keys in the template so we can diff it against the cluster object during retention
+	// to determine whether an annotation/label has been deleted from the template.
+	if _, err := annotationutil.AddAnnotation(
+		obj, common.TemplateAnnotationKeys,
+		strings.Join(sets.List(sets.KeySet(obj.GetAnnotations())), ","),
+	); err != nil {
+		return nil, err
+	}
+	if _, err := annotationutil.AddAnnotation(
+		obj, common.TemplateLabelKeys,
+		strings.Join(sets.List(sets.KeySet(obj.GetLabels())), ","),
+	); err != nil {
+		return nil, err
+	}
+
 	// Avoid having to duplicate these details in the template or have
 	// the name/namespace vary between host and member clusters.
 	// TODO: consider omitting these fields in the template created by federate controller


### PR DESCRIPTION
- don't sync labels like `kubeadmiral.io/propagation-policy-name` to members
- merge desired and observed labels during update to allow controllers in member clusters to manipulate labels
- propagate deletion of labels/annotation from template to members