### PR TITLE
remove pathDefinition in ftc for statefulset

### DIFF
--- a/config/sample/host/01-ftc.yaml
+++ b/config/sample/host/01-ftc.yaml
@@ -469,11 +469,6 @@ spec:
     - - kubeadmiral.io/global-scheduler
     - - kubeadmiral.io/overridepolicy-controller
     - - kubeadmiral.io/follower-controller
-  pathDefinition:
-    labelSelector: spec.selector
-    replicasSpec: spec.replicas
-    replicasStatus: status.replicas
-    readyReplicasStatus: status.readyReplicas
   statusCollection:
     fields:
       - metadata.creationTimestamp


### PR DESCRIPTION
As `Divide` scheduling mode is not supported for statefuleset, `pathDefinition` field should be removed in ftc