### PR TITLE
add syncedGeneration field in federated object

### DIFF
--- a/pkg/apis/types/v1alpha1/types_status.go
+++ b/pkg/apis/types/v1alpha1/types_status.go
@@ -36,10 +36,10 @@ type GenericObjectWithStatus struct {
 }
 
 type GenericFederatedStatus struct {
-	CollisionCount     *int32                 `json:"collisionCount,omitempty"`
-	ObservedGeneration int64                  `json:"observedGeneration,omitempty"`
-	Conditions         []*GenericCondition    `json:"conditions,omitempty"`
-	Clusters           []GenericClusterStatus `json:"clusters,omitempty"`
+	CollisionCount   *int32                 `json:"collisionCount,omitempty"`
+	SyncedGeneration int64                  `json:"syncedGeneration,omitempty"`
+	Conditions       []*GenericCondition    `json:"conditions,omitempty"`
+	Clusters         []GenericClusterStatus `json:"clusters,omitempty"`
 }
 
 type GenericCondition struct {

--- a/pkg/controllers/federatedtypeconfig/crd_schema.go
+++ b/pkg/controllers/federatedtypeconfig/crd_schema.go
@@ -40,6 +40,9 @@ openAPIV3Schema:
 		status:
 			type: object
 			properties:
+				syncedGeneration:
+					format: int64
+					type: integer
 				clusters:
 					type: array
 					items:

--- a/pkg/controllers/federatedtypeconfig/federatedtypeconfig_controller.go
+++ b/pkg/controllers/federatedtypeconfig/federatedtypeconfig_controller.go
@@ -672,7 +672,7 @@ func (c *Controller) startSyncController(tc *fedcorev1a1.FederatedTypeConfig) er
 		go c.controllerRevisionController.Run(stopChan)
 	}
 
-	err := synccontroller.StartKubeFedSyncController(
+	err := synccontroller.StartSyncController(
 		controllerConfig,
 		stopChan,
 		ftc,

--- a/pkg/controllers/sync/dispatch/managed.go
+++ b/pkg/controllers/sync/dispatch/managed.go
@@ -400,8 +400,8 @@ func (d *managedDispatcherImpl) Update(clusterName string, clusterObj *unstructu
 		if util.IsExplicitlyUnmanaged(clusterObj) {
 			err := errors.Errorf(
 				"Unable to manage the object which has label %s: %s",
-				util.ManagedByKubeFedLabelKey,
-				util.UnmanagedByKubeFedLabelValue,
+				util.ManagedByKubeAdmiralLabelKey,
+				util.UnmanagedByKubeAdmiralLabelValue,
 			)
 			return d.recordOperationError(fedtypesv1a1.ManagedLabelFalse, clusterName, op, err)
 		}
@@ -482,8 +482,8 @@ func (d *managedDispatcherImpl) PatchAndKeepTemplate(
 		if util.IsExplicitlyUnmanaged(clusterObj) {
 			err := errors.Errorf(
 				"Unable to manage the object which has label %s: %s",
-				util.ManagedByKubeFedLabelKey,
-				util.UnmanagedByKubeFedLabelValue,
+				util.ManagedByKubeAdmiralLabelKey,
+				util.UnmanagedByKubeAdmiralLabelValue,
 			)
 			return d.recordOperationError(fedtypesv1a1.ManagedLabelFalse, clusterName, op, err)
 		}

--- a/pkg/controllers/sync/history.go
+++ b/pkg/controllers/sync/history.go
@@ -35,7 +35,7 @@ import (
 // syncRevisions update current history revision number, or create current history if need to.
 // It also deduplicates current history, and keeps quantity of history within historyLimit.
 // It returns collision count, latest revision name, current revision name and possible error
-func (s *KubeFedSyncController) syncRevisions(fedResource FederatedResource) (*int32, string, string, error) {
+func (s *SyncController) syncRevisions(fedResource FederatedResource) (*int32, string, string, error) {
 	var (
 		oldRevisions     []*appsv1.ControllerRevision
 		currentRevisions []*appsv1.ControllerRevision
@@ -144,7 +144,7 @@ func IsLabelSubset(x, y map[string]string) bool {
 	return true
 }
 
-func (s *KubeFedSyncController) updateRevisionLabel(
+func (s *SyncController) updateRevisionLabel(
 	revision *appsv1.ControllerRevision,
 	labels map[string]string,
 ) error {
@@ -167,7 +167,7 @@ func (s *KubeFedSyncController) updateRevisionLabel(
 	return nil
 }
 
-func (s *KubeFedSyncController) truncateRevisions(revisions []*appsv1.ControllerRevision, limit int64) error {
+func (s *SyncController) truncateRevisions(revisions []*appsv1.ControllerRevision, limit int64) error {
 	history.SortControllerRevisions(revisions)
 	toKill := len(revisions) - int(limit)
 	for _, revision := range revisions {
@@ -186,7 +186,7 @@ func (s *KubeFedSyncController) truncateRevisions(revisions []*appsv1.Controller
 	return nil
 }
 
-func (s *KubeFedSyncController) listRevisions(fedResource FederatedResource) ([]*appsv1.ControllerRevision, error) {
+func (s *SyncController) listRevisions(fedResource FederatedResource) ([]*appsv1.ControllerRevision, error) {
 	selector := labels.SelectorFromSet(revisionLabels(fedResource))
 	return s.controllerHistory.ListControllerRevisions(fedResource.Object(), selector)
 }
@@ -215,7 +215,7 @@ func newRevision(
 }
 
 // dedupCurRevisions deduplicates current revisions and returns the revision to keep
-func (s *KubeFedSyncController) dedupCurRevisions(
+func (s *SyncController) dedupCurRevisions(
 	dupRevisions []*appsv1.ControllerRevision,
 ) (*appsv1.ControllerRevision, error) {
 	if len(dupRevisions) == 0 {

--- a/pkg/controllers/sync/status/status.go
+++ b/pkg/controllers/sync/status/status.go
@@ -91,9 +91,9 @@ func update(
 	reason fedtypesv1a1.AggregateReason,
 	collectedStatus CollectedPropagationStatus,
 ) bool {
-	generationUpdated := s.ObservedGeneration != generation
+	generationUpdated := s.SyncedGeneration != generation
 	if generationUpdated {
-		s.ObservedGeneration = generation
+		s.SyncedGeneration = generation
 	}
 
 	collisionCountUpdated := !reflect.DeepEqual(s.CollisionCount, collisionCount)

--- a/pkg/controllers/util/annotation/annotation.go
+++ b/pkg/controllers/util/annotation/annotation.go
@@ -20,15 +20,14 @@ import (
 	"fmt"
 	"reflect"
 
-	meta "k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
 const (
-	SyncSuccessTimestamp          = "syncSuccessTimestamp"
-	LastGeneration                = "lastGereration"
-	LastSyncSucceessGeneration    = "lastSyncSucceessGeneration"
-	LastScheduleSuccessGeneration = "lastScheduleSuccessGeneration"
+	SyncSuccessTimestamp       = "syncSuccessTimestamp"
+	LastGeneration             = "lastGeneration"
+	LastSyncSucceessGeneration = "lastSyncSucceessGeneration"
 )
 
 // HasAnnotationKey returns true if the given object has the given annotation key in its ObjectMeta.

--- a/pkg/controllers/util/managedlabel.go
+++ b/pkg/controllers/util/managedlabel.go
@@ -26,11 +26,11 @@ import (
 	"github.com/kubewharf/kubeadmiral/pkg/controllers/common"
 )
 
-var ManagedByKubeFedLabelKey = common.DefaultPrefix + "managed"
+var ManagedByKubeAdmiralLabelKey = common.DefaultPrefix + "managed"
 
 const (
-	ManagedByKubeFedLabelValue   = "true"
-	UnmanagedByKubeFedLabelValue = "false"
+	ManagedByKubeAdmiralLabelValue   = "true"
+	UnmanagedByKubeAdmiralLabelValue = "false"
 )
 
 // HasManagedLabel indicates whether the given object has the managed
@@ -40,7 +40,7 @@ func HasManagedLabel(obj *unstructured.Unstructured) bool {
 	if labels == nil {
 		return false
 	}
-	return labels[ManagedByKubeFedLabelKey] == ManagedByKubeFedLabelValue
+	return labels[ManagedByKubeAdmiralLabelKey] == ManagedByKubeAdmiralLabelValue
 }
 
 // IsExplicitlyUnmanaged indicates whether the given object has the managed
@@ -50,7 +50,7 @@ func IsExplicitlyUnmanaged(obj *unstructured.Unstructured) bool {
 	if labels == nil {
 		return false
 	}
-	return labels[ManagedByKubeFedLabelKey] == UnmanagedByKubeFedLabelValue
+	return labels[ManagedByKubeAdmiralLabelKey] == UnmanagedByKubeAdmiralLabelValue
 }
 
 // AddManagedLabel ensures that the given object has the managed
@@ -60,7 +60,7 @@ func AddManagedLabel(obj *unstructured.Unstructured) {
 	if labels == nil {
 		labels = make(map[string]string)
 	}
-	labels[ManagedByKubeFedLabelKey] = ManagedByKubeFedLabelValue
+	labels[ManagedByKubeAdmiralLabelKey] = ManagedByKubeAdmiralLabelValue
 	obj.SetLabels(labels)
 }
 
@@ -68,9 +68,9 @@ func AddManagedLabel(obj *unstructured.Unstructured) {
 // managed label.
 func RemoveManagedLabel(obj *unstructured.Unstructured) {
 	labels := obj.GetLabels()
-	if labels == nil || labels[ManagedByKubeFedLabelKey] != ManagedByKubeFedLabelValue {
+	if labels == nil || labels[ManagedByKubeAdmiralLabelKey] != ManagedByKubeAdmiralLabelValue {
 		return
 	}
-	delete(labels, ManagedByKubeFedLabelKey)
+	delete(labels, ManagedByKubeAdmiralLabelKey)
 	obj.SetLabels(labels)
 }

--- a/pkg/controllers/util/resourceinformer.go
+++ b/pkg/controllers/util/resourceinformer.go
@@ -75,7 +75,7 @@ func NewManagedResourceInformer(
 	extraTags map[string]string,
 	metrics stats.Metrics,
 ) (cache.Store, cache.Controller) {
-	labelSelector := labels.Set(map[string]string{ManagedByKubeFedLabelKey: ManagedByKubeFedLabelValue}).
+	labelSelector := labels.Set(map[string]string{ManagedByKubeAdmiralLabelKey: ManagedByKubeAdmiralLabelValue}).
 		AsSelector().
 		String()
 	return newResourceInformer(


### PR DESCRIPTION
Main contribution:
- add `syncedGeneration` field in federated object
- rename variables with `KubeFed` to `KubeAdmiral`

After this pr merged, users can see the syncedGeneration in federated object status:
```
status:
  clusters:
  - generation: 1
    name: kubeadmiral-member-1
    status: OK
  - generation: 1
    name: kubeadmiral-member-2
    status: OK
  - generation: 1
    name: kubeadmiral-member-3
    status: OK
  conditions:
  - lastTransitionTime: "2023-05-30T12:36:20Z"
    lastUpdateTime: "2023-05-30T12:36:20Z"
    status: "True"
    type: Propagation
  syncedGeneration: 10
``` 