### PR TITLE
docs: update the content about cluster installation in quickstart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,8 @@ debug: build
 #   TAG:       image tag, the default value is "latest"
 #   ARCHS:     list of target architectures, e.g.:amd64,arm64,arm. The default value is host arch
 #   GOPROXY:   it specifies the download address of the dependent package
+#   REGION:    region to build. e.g.: 'cn' means china mainland(the default value),
+#              the script will set the remote mirror address according to the region to speed up the build.
 #
 # Examples:
 #   # build images with the host arch, it will generate "ghcr.io/kubewharf/kubeadmiral-controller-manager:latest"
@@ -88,7 +90,7 @@ debug: build
 #   make images ARCHS=amd64,arm64
 .PHONY: images
 images:
-	REGISTRY=$(REGISTRY) TAG=$(TAG) ARCHS=$(ARCHS) GOPROXY=$(GOPROXY) bash hack/make-rules/build-images.sh
+	REGISTRY=$(REGISTRY) TAG=$(TAG) ARCHS=$(ARCHS) GOPROXY=$(GOPROXY) REGION=$(REGION) bash hack/make-rules/build-images.sh
 
 # Clean built binaries
 .PHONY: clean

--- a/hack/dockerfiles/Dockerfile
+++ b/hack/dockerfiles/Dockerfile
@@ -6,8 +6,8 @@ WORKDIR /build/
 RUN CGO_ENABLED=0 BUILD_PLATFORMS=${TARGETPLATFORM} GOPROXY=${GOPROXY} make build
 
 FROM --platform=${TARGETPLATFORM} alpine:3.17
-ARG TARGETOS TARGETARCH
-
+ARG TARGETOS TARGETARCH REGION
+RUN if [ "${REGION}" = "cn" ]; then echo -e http://mirrors.ustc.edu.cn/alpine/v3.17/main/ > /etc/apk/repositories; fi
 RUN apk add --no-cache ca-certificates bash && update-ca-certificates
 COPY --from=builder /build/output/bin/${TARGETOS}/${TARGETARCH}/kubeadmiral-controller-manager kubeadmiral-controller-manager
 ENTRYPOINT ["/kubeadmiral-controller-manager"]

--- a/hack/make-rules/build-images.sh
+++ b/hack/make-rules/build-images.sh
@@ -36,12 +36,13 @@ REGISTRY=${REGISTRY:-"ghcr.io/kubewharf"}
 OUTPUT_TYPE=${OUTPUT_TYPE:-"docker"}
 DOCKER_BUILD_ARGS="${DOCKER_BUILD_ARGS:-}"
 GOPROXY=${GOPROXY:-$(go env GOPROXY)}
+REGION=${REGION:-"cn"}
 
 if [[ ${#arch_array[@]} -gt 1 ]]; then
   # If you build images for multiple platforms at one time, the image tag will be added with the architecture name.
   for arch in ${arch_array[@]}; do
-    build::build_images "${REGISTRY}/${COMPENT_NAME}:${TAG}-${arch}" ${DOCKERFILE_PATH} "linux/${arch}" ${OUTPUT_TYPE} "${DOCKER_BUILD_ARGS} --build-arg GOPROXY=${GOPROXY}"
+    build::build_images "${REGISTRY}/${COMPENT_NAME}:${TAG}-${arch}" ${DOCKERFILE_PATH} "linux/${arch}" ${OUTPUT_TYPE} "${DOCKER_BUILD_ARGS} --build-arg GOPROXY=${GOPROXY} --build-arg REGION=${REGION}"
   done
 else
-  build::build_images "${REGISTRY}/${COMPENT_NAME}:${TAG}" ${DOCKERFILE_PATH} "${PLATFORMS}" ${OUTPUT_TYPE} "${DOCKER_BUILD_ARGS} --build-arg GOPROXY=${GOPROXY}"
+  build::build_images "${REGISTRY}/${COMPENT_NAME}:${TAG}" ${DOCKERFILE_PATH} "${PLATFORMS}" ${OUTPUT_TYPE} "${DOCKER_BUILD_ARGS} --build-arg GOPROXY=${GOPROXY} --build-arg REGION=${REGION}"
 fi

--- a/hack/make-rules/clean-local-cluster.sh
+++ b/hack/make-rules/clean-local-cluster.sh
@@ -23,8 +23,6 @@ if [[ ! $(kind get clusters | grep kubeadmiral ) ]]; then
 else
   kind delete clusters $(kind get clusters | grep kubeadmiral | tr -s "\r\n" " ")
   echo "The following files will be deleted:
-  ${HOME}/.kube/kubeadmiral.config
-  ${HOME}/.kube/members.config
   ${HOME}/.kube/kubeadmiral"
-  rm -rf ${HOME}/.kube/kubeadmiral.config ${HOME}/.kube/members.config ${HOME}/.kube/kubeadmiral
+  rm -rf ${HOME}/.kube/kubeadmiral
 fi


### PR DESCRIPTION
#### What this PR does?
1. Update the content about cluster installation in quickstart;
2. Starting the kubeadmiral cluster will no longer directly modify the files in the repository;
3. Split the kubeconfig of kubeadmiral-host and kubeadmiral-meta into two to reduce the cost of using local kubeadmiral for users.

#### Does this PR introduce a user-facing change?
If everything went well in the installation steps, we will see the following messages:
```
Your local KubeAdmiral has been deployed successfully!

To start using your KubeAdmiral, run:
  export KUBECONFIG=$HOME/.kube/kubeadmiral/kubeadmiral.config
  
To observe the status of KubeAdmiral control-plane components, run:
  export KUBECONFIG=$HOME/.kube/kubeadmiral/meta.config

To manage your member clusters, run:
  export KUBECONFIG=$HOME/.kube/members.config
Please use 'kubectl config use-context kubeadmiral-member-1/kubeadmiral-member-2/kubeadmiral-member-3' to switch to the different member cluster.
```