### PR TITLE
record the pruning merge patches for source object in the annotations of federated object

### DIFF
--- a/pkg/controllers/common/constants.go
+++ b/pkg/controllers/common/constants.go
@@ -116,7 +116,7 @@ const (
 
 	NoSchedulingAnnotation = DefaultPrefix + "no-scheduling"
 
-	// FederatedObjectAnnotation indicates that that the object was created by the federate controller.
+	// FederatedObjectAnnotation indicates that the object was created by the federate controller.
 	FederatedObjectAnnotation = DefaultPrefix + "federated-object"
 
 	// FollowersAnnotation indicates the additional followers of a leader.
@@ -135,6 +135,9 @@ const (
 	// ObservedLabelKeysAnnotation contains label keys observed in the last reconcile.
 	// It will be in the format of `a,b|c,d`, where `a` and `b` are the keys that are synced from source labels to federated object labels.
 	ObservedLabelKeysAnnotation = FederateControllerPrefix + "observed-labels"
+	// TemplateGeneratorMergePatchAnnotation indicates the merge patch document capable of converting
+	// the source object to the template object.
+	TemplateGeneratorMergePatchAnnotation = FederateControllerPrefix + "template-generator-merge-patch"
 )
 
 // TemplateAnnotationKeys and TemplateLabelKeys are used to store the keys of annotations and labels that are present


### PR DESCRIPTION
Main contribution:
- record the merge patch document for source object in the annotations of federated object 

the annotation is shown as below:
```kubeadmiral.io/template-generator-merge-patch: '{"metadata":{"annotations":{"kubeadmiral.io/latest-replicaset-digests":null,"kubeadmiral.io/scheduling":null,"kubeadmiral.io/status":null,"kubeadmiral.io/syncing":null},"creationTimestamp":null,"finalizers":null,"generation":null,"labels":{"kubeadmiral.io/propagation-policy-name":null},"managedFields":null,"resourceVersion":null,"uid":null},"status":null}'```