### PR TITLE
feat: add status aggregator plugins for job and pod

### DIFF
--- a/pkg/controllers/statusaggregator/controller.go
+++ b/pkg/controllers/statusaggregator/controller.go
@@ -297,7 +297,6 @@ func (a *StatusAggregator) reconcile(qualifiedName common.QualifiedName) (status
 
 	newObj, needUpdate, err := a.plugin.AggregateStatuses(ctx, sourceObject, fedObject, clusterObjs, clusterObjsUpToDate)
 	if err != nil {
-		logger.Error(err, "Failed to aggregate statuses")
 		return worker.StatusError
 	}
 

--- a/pkg/controllers/statusaggregator/plugins/job.go
+++ b/pkg/controllers/statusaggregator/plugins/job.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2023 The KubeAdmiral Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugins
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
+
+	"github.com/kubewharf/kubeadmiral/pkg/controllers/common"
+)
+
+type JobPlugin struct{}
+
+func NewJobPlugin() *JobPlugin {
+	return &JobPlugin{}
+}
+
+func (receiver *JobPlugin) AggregateStatuses(
+	ctx context.Context,
+	sourceObject, fedObject *unstructured.Unstructured,
+	clusterObjs map[string]interface{},
+	clusterObjsUpToDate bool,
+) (*unstructured.Unstructured, bool, error) {
+	logger := klog.FromContext(ctx).WithValues("status-aggregator-plugin", "jobs")
+
+	aggregatedStatus := &batchv1.JobStatus{}
+	var completionTime *metav1.Time
+	var finishedCount int
+	var completedJobs, failedJobs []string
+
+	for clusterName, clusterObj := range clusterObjs {
+		logger := klog.FromContext(ctx).WithValues("cluster-name", clusterName)
+
+		utd := clusterObj.(*unstructured.Unstructured)
+		// For status of job
+		var found bool
+		status, found, err := unstructured.NestedMap(utd.Object, common.StatusField)
+		if err != nil || !found {
+			logger.Error(err, "Failed to get status of cluster object")
+			return nil, false, err
+		}
+
+		if status == nil {
+			continue
+		}
+
+		jobStatus := &batchv1.JobStatus{}
+		if err = runtime.DefaultUnstructuredConverter.FromUnstructured(status, jobStatus); err != nil {
+			logger.Error(err, "Failed to convert the status of cluster object")
+			return nil, false, err
+		}
+
+		if aggregatedStatus.StartTime.IsZero() || jobStatus.StartTime.Before(aggregatedStatus.StartTime) {
+			aggregatedStatus.StartTime = jobStatus.StartTime
+		}
+		if !jobStatus.CompletionTime.IsZero() {
+			finishedCount++
+			completedJobs = append(completedJobs, clusterName)
+			if completionTime.IsZero() || completionTime.Before(jobStatus.CompletionTime) {
+				completionTime = jobStatus.CompletionTime
+			}
+		} else if IsJobFinishedWithFailed(jobStatus) {
+			finishedCount++
+			failedJobs = append(failedJobs, clusterName)
+		}
+
+		aggregatedStatus.Active += jobStatus.Active
+		aggregatedStatus.Succeeded += jobStatus.Succeeded
+		aggregatedStatus.Failed += jobStatus.Failed
+	}
+	if finishedCount > 0 && finishedCount == len(clusterObjs) {
+		now := time.Now()
+		var conditionType batchv1.JobConditionType
+		var reason, message string
+		sort.Strings(completedJobs)
+		sort.Strings(failedJobs)
+
+		switch {
+		case len(completedJobs) > 0 && len(failedJobs) > 0:
+			conditionType = batchv1.JobFailed
+			reason = "Mixed"
+			message = fmt.Sprintf("Job completed in clusters [%s] and failed in member clusters [%s]",
+				strings.Join(completedJobs, ","), strings.Join(failedJobs, ","))
+		case len(completedJobs) > 0:
+			conditionType = batchv1.JobComplete
+			reason = "Completed"
+			message = fmt.Sprintf("Job completed in clusters [%s]", strings.Join(completedJobs, ","))
+			aggregatedStatus.CompletionTime = completionTime
+		default:
+			conditionType = batchv1.JobFailed
+			reason = "Failed"
+			message = fmt.Sprintf("Job failed in clusters [%s]", strings.Join(failedJobs, ","))
+		}
+
+		aggregatedStatus.Conditions = append(aggregatedStatus.Conditions, batchv1.JobCondition{
+			Type:               conditionType,
+			Status:             corev1.ConditionTrue,
+			LastProbeTime:      metav1.NewTime(now),
+			LastTransitionTime: metav1.NewTime(now),
+			Reason:             reason,
+			Message:            message,
+		})
+	}
+
+	newStatus, err := runtime.DefaultUnstructuredConverter.ToUnstructured(aggregatedStatus)
+	if err != nil {
+		logger.Error(err, "Failed to convert aggregated status to unstructured")
+		return nil, false, err
+	}
+
+	oldStatus, _, err := unstructured.NestedMap(sourceObject.Object, common.StatusField)
+	if err != nil {
+		logger.Error(err, "Failed to get old status of source object")
+		return nil, false, err
+	}
+
+	// update status of source object if needed
+	needUpdate := false
+	if !reflect.DeepEqual(newStatus, oldStatus) {
+		if err := unstructured.SetNestedMap(sourceObject.Object, newStatus, common.StatusField); err != nil {
+			logger.Error(err, "Failed to set the new status on source object")
+			return nil, false, err
+		}
+		needUpdate = true
+	}
+
+	return sourceObject, needUpdate, nil
+}
+
+// IsJobFinishedWithFailed checks whether the given Job has finished execution with failed condition.
+func IsJobFinishedWithFailed(jobStatus *batchv1.JobStatus) bool {
+	for _, c := range jobStatus.Conditions {
+		if c.Type == batchv1.JobFailed && c.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/controllers/statusaggregator/plugins/job_test.go
+++ b/pkg/controllers/statusaggregator/plugins/job_test.go
@@ -1,0 +1,317 @@
+/*
+Copyright 2023 The KubeAdmiral Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugins
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
+)
+
+func TestJobPlugin(t *testing.T) {
+	testTime := time.Now()
+
+	completedJobStartTime := metav1.NewTime(testTime.Add(-10 * time.Second))
+	completedJobCompletionTime := metav1.NewTime(testTime)
+	completedJob := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "completed",
+			Namespace: "default",
+		},
+		Status: batchv1.JobStatus{
+			Conditions:     []batchv1.JobCondition{{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}},
+			StartTime:      completedJobStartTime.DeepCopy(),
+			CompletionTime: completedJobCompletionTime.DeepCopy(),
+			Active:         1,
+			Succeeded:      1,
+			Failed:         1,
+		},
+	}
+	u1, err := runtime.DefaultUnstructuredConverter.ToUnstructured(completedJob)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	uCompletedJob := &unstructured.Unstructured{Object: u1}
+
+	failedJobStartTime := metav1.NewTime(testTime.Add(-15 * time.Second))
+	failedJob := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "failed",
+			Namespace: "default",
+		},
+		Status: batchv1.JobStatus{
+			Conditions: []batchv1.JobCondition{{Type: batchv1.JobFailed, Status: corev1.ConditionTrue}},
+			StartTime:  failedJobStartTime.DeepCopy(),
+			Active:     0,
+			Succeeded:  0,
+			Failed:     1,
+		},
+	}
+	u2, err := runtime.DefaultUnstructuredConverter.ToUnstructured(failedJob)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	uFailedJob := &unstructured.Unstructured{Object: u2}
+
+	suspendedJobStartTime := metav1.NewTime(testTime.Add(-15 * time.Second))
+	suspendedJob := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "suspended",
+			Namespace: "default",
+		},
+		Status: batchv1.JobStatus{
+			Conditions: []batchv1.JobCondition{{Type: batchv1.JobSuspended, Status: corev1.ConditionTrue}},
+			StartTime:  suspendedJobStartTime.DeepCopy(),
+		},
+	}
+	u3, err := runtime.DefaultUnstructuredConverter.ToUnstructured(suspendedJob)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	uSuspendedJob := &unstructured.Unstructured{Object: u3}
+
+	tests := []struct {
+		name string
+
+		sourceObject *unstructured.Unstructured
+		fedObject    *unstructured.Unstructured
+		clusterObjs  map[string]interface{}
+
+		expectedErr        error
+		expectedNeedUpdate bool
+		expectedJobStatus  *batchv1.JobStatus
+	}{
+		{
+			name:               "2 completed jobs, need update",
+			sourceObject:       uCompletedJob.DeepCopy(),
+			fedObject:          &unstructured.Unstructured{},
+			clusterObjs:        map[string]interface{}{"c1": uCompletedJob.DeepCopy(), "c2": uCompletedJob.DeepCopy()},
+			expectedErr:        nil,
+			expectedNeedUpdate: true,
+			expectedJobStatus: &batchv1.JobStatus{
+				Conditions: []batchv1.JobCondition{{
+					Type:    batchv1.JobComplete,
+					Status:  corev1.ConditionTrue,
+					Reason:  "Completed",
+					Message: "Job completed in clusters [c1,c2]",
+				}},
+				StartTime:      completedJobStartTime.DeepCopy(),
+				CompletionTime: completedJobCompletionTime.DeepCopy(),
+				Active:         2,
+				Succeeded:      2,
+				Failed:         2,
+			},
+		},
+		{
+			name:               "1 completed job, 1 failed job, need update",
+			sourceObject:       uCompletedJob.DeepCopy(),
+			fedObject:          &unstructured.Unstructured{},
+			clusterObjs:        map[string]interface{}{"c1": uCompletedJob.DeepCopy(), "c2": uFailedJob.DeepCopy()},
+			expectedErr:        nil,
+			expectedNeedUpdate: true,
+			expectedJobStatus: &batchv1.JobStatus{
+				Conditions: []batchv1.JobCondition{{
+					Type:    batchv1.JobFailed,
+					Status:  corev1.ConditionTrue,
+					Reason:  "Mixed",
+					Message: "Job completed in clusters [c1] and failed in member clusters [c2]",
+				}},
+				StartTime: failedJobStartTime.DeepCopy(),
+				Active:    1,
+				Succeeded: 1,
+				Failed:    2,
+			},
+		},
+		{
+			name:               "2 failed jobs, need update",
+			sourceObject:       uCompletedJob.DeepCopy(),
+			fedObject:          &unstructured.Unstructured{},
+			clusterObjs:        map[string]interface{}{"c1": uFailedJob.DeepCopy(), "c2": uFailedJob.DeepCopy()},
+			expectedErr:        nil,
+			expectedNeedUpdate: true,
+			expectedJobStatus: &batchv1.JobStatus{
+				Conditions: []batchv1.JobCondition{{
+					Type:    batchv1.JobFailed,
+					Status:  corev1.ConditionTrue,
+					Reason:  "Failed",
+					Message: "Job failed in clusters [c1,c2]",
+				}},
+				StartTime: failedJobStartTime.DeepCopy(),
+				Active:    0,
+				Succeeded: 0,
+				Failed:    2,
+			},
+		},
+		{
+			name:               "1 completed job, 1 suspended job, need update",
+			sourceObject:       uCompletedJob.DeepCopy(),
+			fedObject:          &unstructured.Unstructured{},
+			clusterObjs:        map[string]interface{}{"c1": uCompletedJob.DeepCopy(), "c2": uSuspendedJob.DeepCopy()},
+			expectedErr:        nil,
+			expectedNeedUpdate: true,
+			expectedJobStatus: &batchv1.JobStatus{
+				StartTime: suspendedJobStartTime.DeepCopy(),
+				Active:    1,
+				Succeeded: 1,
+				Failed:    1,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := klog.NewContext(context.Background(), klog.Background())
+			receiver := NewJobPlugin()
+
+			got, needUpdate, err := receiver.AggregateStatuses(ctx, tt.sourceObject, tt.fedObject, tt.clusterObjs, false)
+			if !errors.Is(err, tt.expectedErr) {
+				t.Fatalf("got error: %v, expectedErr: %v", err, tt.expectedErr)
+			}
+			// if err was expected, just pass it
+			if err != nil {
+				return
+			}
+			if needUpdate != tt.expectedNeedUpdate {
+				t.Fatalf("got needUpdate: %v, expectedNeedUpdate: %v", needUpdate, tt.expectedNeedUpdate)
+			}
+
+			if conds, found, err := unstructured.NestedSlice(got.Object, "status", "conditions"); err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			} else if found {
+				// ignore lastProbeTime and lastTransitionTime of conditions
+				// to avoid time conflict due to processor processing
+				for i := range conds {
+					err = unstructured.SetNestedField(conds[i].(map[string]interface{}), nil, "lastProbeTime")
+					if err != nil {
+						t.Fatalf("unexpected err: %v", err)
+					}
+					err = unstructured.SetNestedField(conds[i].(map[string]interface{}), nil, "lastTransitionTime")
+					if err != nil {
+						t.Fatalf("unexpected err: %v", err)
+					}
+				}
+				err = unstructured.SetNestedField(got.Object, conds, "status", "conditions")
+				if err != nil {
+					t.Fatalf("unexpected err: %v", err)
+				}
+			}
+			uExpectedJobStatus, err := runtime.DefaultUnstructuredConverter.ToUnstructured(tt.expectedJobStatus)
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+
+			uGotStatus, _, _ := unstructured.NestedMap(got.Object, "status")
+			if !reflect.DeepEqual(uExpectedJobStatus, uGotStatus) {
+				t.Fatalf("got jobStatus: %v, expected jobStatus: %v", uGotStatus, uExpectedJobStatus)
+			}
+		})
+	}
+}
+
+func TestIsJobFinishedWithFailed(t *testing.T) {
+	testCases := map[string]struct {
+		conditionType               batchv1.JobConditionType
+		conditionStatus             corev1.ConditionStatus
+		expectJobFinishedWithFailed bool
+	}{
+		"Job is completed and condition is true": {
+			batchv1.JobComplete,
+			corev1.ConditionTrue,
+			false,
+		},
+		"Job is completed and condition is false": {
+			batchv1.JobComplete,
+			corev1.ConditionFalse,
+			false,
+		},
+		"Job is completed and condition is unknown": {
+			batchv1.JobComplete,
+			corev1.ConditionUnknown,
+			false,
+		},
+
+		"Job is failed and condition is true": {
+			batchv1.JobFailed,
+			corev1.ConditionTrue,
+			true,
+		},
+		"Job is failed and condition is false": {
+			batchv1.JobFailed,
+			corev1.ConditionFalse,
+			false,
+		},
+		"Job is failed and condition is unknown": {
+			batchv1.JobFailed,
+			corev1.ConditionUnknown,
+			false,
+		},
+
+		"Job is suspended and condition is true": {
+			batchv1.JobSuspended,
+			corev1.ConditionTrue,
+			false,
+		},
+		"Job is suspended and condition is false": {
+			batchv1.JobSuspended,
+			corev1.ConditionFalse,
+			false,
+		},
+		"Job is suspended and condition is unknown": {
+			batchv1.JobSuspended,
+			corev1.ConditionUnknown,
+			false,
+		},
+
+		"Job is about to fail its execution and condition is true": {
+			batchv1.JobFailureTarget,
+			corev1.ConditionTrue,
+			false,
+		},
+		"Job is about to fail its execution and condition is false": {
+			batchv1.JobFailureTarget,
+			corev1.ConditionFalse,
+			false,
+		},
+		"Job is about to fail its execution and condition is unknown": {
+			batchv1.JobFailureTarget,
+			corev1.ConditionUnknown,
+			false,
+		},
+	}
+
+	for name, tc := range testCases {
+		status := &batchv1.JobStatus{
+			Conditions: []batchv1.JobCondition{{
+				Type:   tc.conditionType,
+				Status: tc.conditionStatus,
+			}},
+		}
+
+		if tc.expectJobFinishedWithFailed != IsJobFinishedWithFailed(status) {
+			t.Errorf("test name: %s, job was not expected", name)
+		}
+	}
+}

--- a/pkg/controllers/statusaggregator/plugins/plugin.go
+++ b/pkg/controllers/statusaggregator/plugins/plugin.go
@@ -20,6 +20,8 @@ import (
 	"context"
 
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -40,6 +42,8 @@ type Plugin interface {
 var pluginsMap = map[schema.GroupVersionKind]Plugin{
 	appsv1.SchemeGroupVersion.WithKind(common.DeploymentKind):  NewDeploymentPlugin(),
 	appsv1.SchemeGroupVersion.WithKind(common.StatefulSetKind): NewSingleClusterPlugin(),
+	batchv1.SchemeGroupVersion.WithKind(common.JobKind):        NewJobPlugin(),
+	corev1.SchemeGroupVersion.WithKind(common.PodKind):         NewPodPlugin(),
 }
 
 func GetPlugin(apiResource *metav1.APIResource) Plugin {

--- a/pkg/controllers/statusaggregator/plugins/pod.go
+++ b/pkg/controllers/statusaggregator/plugins/pod.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2023 The KubeAdmiral Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugins
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
+
+	"github.com/kubewharf/kubeadmiral/pkg/controllers/common"
+)
+
+type PodPlugin struct{}
+
+func NewPodPlugin() *PodPlugin {
+	return &PodPlugin{}
+}
+
+func (receiver *PodPlugin) AggregateStatuses(
+	ctx context.Context,
+	sourceObject, fedObject *unstructured.Unstructured,
+	clusterObjs map[string]interface{},
+	clusterObjsUpToDate bool,
+) (*unstructured.Unstructured, bool, error) {
+	logger := klog.FromContext(ctx).WithValues("status-aggregator-plugin", "pods")
+
+	needUpdate := false
+	aggregatedStatus := &corev1.PodStatus{}
+	phases := map[corev1.PodPhase][]string{
+		corev1.PodPending:   make([]string, 0, len(clusterObjs)),
+		corev1.PodRunning:   make([]string, 0, len(clusterObjs)),
+		corev1.PodSucceeded: make([]string, 0, len(clusterObjs)),
+		corev1.PodFailed:    make([]string, 0, len(clusterObjs)),
+		// Ignore phase PodUnknown as it has been deprecated since year 2015.
+	}
+
+	for clusterName, clusterObj := range clusterObjs {
+		logger := klog.FromContext(ctx).WithValues("cluster-name", clusterName)
+
+		utd := clusterObj.(*unstructured.Unstructured)
+		// For status of pod
+		var found bool
+		status, found, err := unstructured.NestedMap(utd.Object, common.StatusField)
+		if err != nil || !found {
+			logger.Error(err, "Failed to get status of cluster object")
+			return nil, false, err
+		}
+
+		if status == nil {
+			continue
+		}
+
+		podStatus := &corev1.PodStatus{}
+		if err = runtime.DefaultUnstructuredConverter.FromUnstructured(status, podStatus); err != nil {
+			logger.Error(err, "Failed to convert the status of cluster object")
+			return nil, false, err
+		}
+
+		if podStatus.Phase == "" {
+			// If the status has not yet been generated, set it to pending as default.
+			phases[corev1.PodPending] = append(phases[corev1.PodPending], clusterName)
+			continue
+		}
+
+		phases[podStatus.Phase] = append(phases[podStatus.Phase], clusterName)
+		if aggregatedStatus.StartTime.IsZero() || podStatus.StartTime.Before(aggregatedStatus.StartTime) {
+			aggregatedStatus.StartTime = podStatus.StartTime
+		}
+		for _, initContainerStatus := range podStatus.InitContainerStatuses {
+			initContainerStatus.Name = fmt.Sprintf("%s (%s)", initContainerStatus.Name, clusterName)
+			aggregatedStatus.InitContainerStatuses = append(aggregatedStatus.InitContainerStatuses, initContainerStatus)
+		}
+		for _, containerStatus := range podStatus.ContainerStatuses {
+			containerStatus.Name = fmt.Sprintf("%s (%s)", containerStatus.Name, clusterName)
+			aggregatedStatus.ContainerStatuses = append(aggregatedStatus.ContainerStatuses, containerStatus)
+		}
+	}
+
+	// Check phase in order: PodFailed-->PodPending-->PodRunning-->PodSucceeded.
+	for _, phase := range []corev1.PodPhase{corev1.PodFailed, corev1.PodPending, corev1.PodRunning, corev1.PodSucceeded} {
+		if len(phases[phase]) == 0 {
+			continue
+		}
+		if aggregatedStatus.Phase == "" {
+			aggregatedStatus.Phase = phase
+		}
+		sort.Strings(phases[phase])
+		if aggregatedStatus.Message == "" {
+			aggregatedStatus.Message = fmt.Sprintf("Pod %s in clusters [%s]",
+				strings.ToLower(string(phase)), strings.Join(phases[phase], ","))
+			continue
+		}
+		aggregatedStatus.Message = fmt.Sprintf("%s, and %s in clusters [%s]",
+			aggregatedStatus.Message, strings.ToLower(string(phase)), strings.Join(phases[phase], ","))
+	}
+	if len(phases) > 4 {
+		logger.Error(errors.New("unknown pod phases"),
+			fmt.Sprintf("Should not happen: %v. Maybe Pod added a new state that KubeAdmiral doesn't know about", phases))
+	}
+
+	// make results stable
+	sort.Slice(aggregatedStatus.InitContainerStatuses, func(i, j int) bool {
+		return aggregatedStatus.InitContainerStatuses[i].Name < aggregatedStatus.InitContainerStatuses[j].Name
+	})
+	sort.Slice(aggregatedStatus.ContainerStatuses, func(i, j int) bool {
+		return aggregatedStatus.ContainerStatuses[i].Name < aggregatedStatus.ContainerStatuses[j].Name
+	})
+
+	newStatus, err := runtime.DefaultUnstructuredConverter.ToUnstructured(aggregatedStatus)
+	if err != nil {
+		logger.Error(err, "Failed to convert aggregated status to unstructured")
+		return nil, false, err
+	}
+
+	oldStatus, _, err := unstructured.NestedMap(sourceObject.Object, common.StatusField)
+	if err != nil {
+		logger.Error(err, "Failed to get old status of source object")
+		return nil, false, err
+	}
+
+	// update status of source object if needed
+	if !reflect.DeepEqual(newStatus, oldStatus) {
+		if err := unstructured.SetNestedMap(sourceObject.Object, newStatus, common.StatusField); err != nil {
+			logger.Error(err, "Failed to set the new status on source object")
+			return nil, false, err
+		}
+		needUpdate = true
+	}
+
+	return sourceObject, needUpdate, nil
+}

--- a/pkg/controllers/statusaggregator/plugins/pod_test.go
+++ b/pkg/controllers/statusaggregator/plugins/pod_test.go
@@ -1,0 +1,364 @@
+/*
+Copyright 2023 The KubeAdmiral Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugins
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
+)
+
+func TestPodPlugin(t *testing.T) {
+	testTime := time.Now()
+
+	failedPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "failed-0",
+		},
+		Status: corev1.PodStatus{
+			Phase:                 corev1.PodFailed,
+			StartTime:             &metav1.Time{Time: testTime.Add(-10 * time.Second)},
+			InitContainerStatuses: []corev1.ContainerStatus{generateContainerStatus("failed-init", true, testTime)},
+			ContainerStatuses:     []corev1.ContainerStatus{generateContainerStatus("failed", true, testTime)},
+		},
+	}
+	u1, err := runtime.DefaultUnstructuredConverter.ToUnstructured(failedPod)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	uFailedPod := &unstructured.Unstructured{Object: u1}
+
+	pendingPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pending-0",
+		},
+		Status: corev1.PodStatus{
+			Phase:                 corev1.PodPending,
+			StartTime:             &metav1.Time{Time: testTime.Add(-20 * time.Second)},
+			InitContainerStatuses: []corev1.ContainerStatus{generateContainerStatus("pending-init", true, testTime)},
+		},
+	}
+	u2, err := runtime.DefaultUnstructuredConverter.ToUnstructured(pendingPod)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	uPendingPod := &unstructured.Unstructured{Object: u2}
+
+	runningPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "running-0",
+		},
+		Status: corev1.PodStatus{
+			Phase:                 corev1.PodRunning,
+			StartTime:             &metav1.Time{Time: testTime.Add(-30 * time.Second)},
+			InitContainerStatuses: []corev1.ContainerStatus{generateContainerStatus("running-init", true, testTime)},
+			ContainerStatuses:     []corev1.ContainerStatus{generateContainerStatus("running", true, testTime)},
+		},
+	}
+	u3, err := runtime.DefaultUnstructuredConverter.ToUnstructured(runningPod)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	uRunningPod := &unstructured.Unstructured{Object: u3}
+
+	succeededPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "succeeded-0",
+		},
+		Status: corev1.PodStatus{
+			Phase:                 corev1.PodSucceeded,
+			StartTime:             &metav1.Time{Time: testTime.Add(-40 * time.Second)},
+			InitContainerStatuses: []corev1.ContainerStatus{generateContainerStatus("succeeded-init", true, testTime)},
+			ContainerStatuses:     []corev1.ContainerStatus{generateContainerStatus("succeeded", true, testTime)},
+		},
+	}
+	u4, err := runtime.DefaultUnstructuredConverter.ToUnstructured(succeededPod)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	uSucceededPod := &unstructured.Unstructured{Object: u4}
+
+	emptyPod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "empty-0"}}
+	u5, err := runtime.DefaultUnstructuredConverter.ToUnstructured(emptyPod)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	uEmptyPod := &unstructured.Unstructured{Object: u5}
+
+	tests := []struct {
+		name string
+
+		sourceObject *unstructured.Unstructured
+		fedObject    *unstructured.Unstructured
+		clusterObjs  map[string]interface{}
+
+		expectedErr        error
+		expectedNeedUpdate bool
+		expectedPodStatus  *corev1.PodStatus
+	}{
+		{
+			name:               "2 failed pods, need update",
+			sourceObject:       uEmptyPod.DeepCopy(),
+			fedObject:          nil,
+			clusterObjs:        map[string]interface{}{"c1": uFailedPod.DeepCopy(), "c2": uFailedPod.DeepCopy()},
+			expectedErr:        nil,
+			expectedNeedUpdate: true,
+			expectedPodStatus: &corev1.PodStatus{
+				Phase:     corev1.PodFailed,
+				Message:   "Pod failed in clusters [c1,c2]",
+				StartTime: &metav1.Time{Time: testTime.Add(-10 * time.Second)},
+				InitContainerStatuses: []corev1.ContainerStatus{
+					generateContainerStatus("failed-init (c1)", true, testTime),
+					generateContainerStatus("failed-init (c2)", true, testTime),
+				},
+				ContainerStatuses: []corev1.ContainerStatus{
+					generateContainerStatus("failed (c1)", true, testTime),
+					generateContainerStatus("failed (c2)", true, testTime),
+				},
+			},
+		},
+		{
+			name:               "2 pending pods, need update",
+			sourceObject:       uEmptyPod.DeepCopy(),
+			fedObject:          nil,
+			clusterObjs:        map[string]interface{}{"c1": uPendingPod.DeepCopy(), "c2": uPendingPod.DeepCopy()},
+			expectedErr:        nil,
+			expectedNeedUpdate: true,
+			expectedPodStatus: &corev1.PodStatus{
+				Phase:     corev1.PodPending,
+				Message:   "Pod pending in clusters [c1,c2]",
+				StartTime: &metav1.Time{Time: testTime.Add(-20 * time.Second)},
+				InitContainerStatuses: []corev1.ContainerStatus{
+					generateContainerStatus("pending-init (c1)", true, testTime),
+					generateContainerStatus("pending-init (c2)", true, testTime),
+				},
+			},
+		},
+		{
+			name:               "2 running pods, need update",
+			sourceObject:       uEmptyPod.DeepCopy(),
+			fedObject:          nil,
+			clusterObjs:        map[string]interface{}{"c1": uRunningPod.DeepCopy(), "c2": uRunningPod.DeepCopy()},
+			expectedErr:        nil,
+			expectedNeedUpdate: true,
+			expectedPodStatus: &corev1.PodStatus{
+				Phase:     corev1.PodRunning,
+				Message:   "Pod running in clusters [c1,c2]",
+				StartTime: &metav1.Time{Time: testTime.Add(-30 * time.Second)},
+				InitContainerStatuses: []corev1.ContainerStatus{
+					generateContainerStatus("running-init (c1)", true, testTime),
+					generateContainerStatus("running-init (c2)", true, testTime),
+				},
+				ContainerStatuses: []corev1.ContainerStatus{
+					generateContainerStatus("running (c1)", true, testTime),
+					generateContainerStatus("running (c2)", true, testTime),
+				},
+			},
+		},
+		{
+			name:               "2 succeeded pods, need update",
+			sourceObject:       uEmptyPod.DeepCopy(),
+			fedObject:          nil,
+			clusterObjs:        map[string]interface{}{"c1": uSucceededPod.DeepCopy(), "c2": uSucceededPod.DeepCopy()},
+			expectedErr:        nil,
+			expectedNeedUpdate: true,
+			expectedPodStatus: &corev1.PodStatus{
+				Phase:     corev1.PodSucceeded,
+				Message:   "Pod succeeded in clusters [c1,c2]",
+				StartTime: &metav1.Time{Time: testTime.Add(-40 * time.Second)},
+				InitContainerStatuses: []corev1.ContainerStatus{
+					generateContainerStatus("succeeded-init (c1)", true, testTime),
+					generateContainerStatus("succeeded-init (c2)", true, testTime),
+				},
+				ContainerStatuses: []corev1.ContainerStatus{
+					generateContainerStatus("succeeded (c1)", true, testTime),
+					generateContainerStatus("succeeded (c2)", true, testTime),
+				},
+			},
+		},
+		{
+			name:               "1 failed pod, 1 succeeded pod, need update",
+			sourceObject:       uEmptyPod.DeepCopy(),
+			fedObject:          nil,
+			clusterObjs:        map[string]interface{}{"c1": uFailedPod.DeepCopy(), "c2": uSucceededPod.DeepCopy()},
+			expectedErr:        nil,
+			expectedNeedUpdate: true,
+			expectedPodStatus: &corev1.PodStatus{
+				Phase:     corev1.PodFailed,
+				Message:   "Pod failed in clusters [c1], and succeeded in clusters [c2]",
+				StartTime: &metav1.Time{Time: testTime.Add(-40 * time.Second)},
+				InitContainerStatuses: []corev1.ContainerStatus{
+					generateContainerStatus("failed-init (c1)", true, testTime),
+					generateContainerStatus("succeeded-init (c2)", true, testTime),
+				},
+				ContainerStatuses: []corev1.ContainerStatus{
+					generateContainerStatus("failed (c1)", true, testTime),
+					generateContainerStatus("succeeded (c2)", true, testTime),
+				},
+			},
+		},
+		{
+			name:               "1 pending pod, 1 running pod, need update",
+			sourceObject:       uEmptyPod.DeepCopy(),
+			fedObject:          nil,
+			clusterObjs:        map[string]interface{}{"c1": uPendingPod.DeepCopy(), "c2": uRunningPod.DeepCopy()},
+			expectedErr:        nil,
+			expectedNeedUpdate: true,
+			expectedPodStatus: &corev1.PodStatus{
+				Phase:     corev1.PodPending,
+				Message:   "Pod pending in clusters [c1], and running in clusters [c2]",
+				StartTime: &metav1.Time{Time: testTime.Add(-30 * time.Second)},
+				InitContainerStatuses: []corev1.ContainerStatus{
+					generateContainerStatus("pending-init (c1)", true, testTime),
+					generateContainerStatus("running-init (c2)", true, testTime),
+				},
+				ContainerStatuses: []corev1.ContainerStatus{
+					generateContainerStatus("running (c2)", true, testTime),
+				},
+			},
+		},
+		{
+			name:               "1 pending pod, 1 empty pod, need update",
+			sourceObject:       uEmptyPod.DeepCopy(),
+			fedObject:          nil,
+			clusterObjs:        map[string]interface{}{"c1": uPendingPod.DeepCopy(), "c2": uEmptyPod.DeepCopy()},
+			expectedErr:        nil,
+			expectedNeedUpdate: true,
+			expectedPodStatus: &corev1.PodStatus{
+				Phase:     corev1.PodPending,
+				Message:   "Pod pending in clusters [c1,c2]",
+				StartTime: &metav1.Time{Time: testTime.Add(-20 * time.Second)},
+				InitContainerStatuses: []corev1.ContainerStatus{
+					generateContainerStatus("pending-init (c1)", true, testTime),
+				},
+			},
+		},
+		{
+			name:               "1 running pod, 1 empty pod, need update",
+			sourceObject:       uEmptyPod.DeepCopy(),
+			fedObject:          nil,
+			clusterObjs:        map[string]interface{}{"c1": uRunningPod.DeepCopy(), "c2": uEmptyPod.DeepCopy()},
+			expectedErr:        nil,
+			expectedNeedUpdate: true,
+			expectedPodStatus: &corev1.PodStatus{
+				Phase:     corev1.PodPending,
+				Message:   "Pod pending in clusters [c2], and running in clusters [c1]",
+				StartTime: &metav1.Time{Time: testTime.Add(-30 * time.Second)},
+				InitContainerStatuses: []corev1.ContainerStatus{
+					generateContainerStatus("running-init (c1)", true, testTime),
+				},
+				ContainerStatuses: []corev1.ContainerStatus{
+					generateContainerStatus("running (c1)", true, testTime),
+				},
+			},
+		},
+		{
+			name:               "2 empty pods, need update",
+			sourceObject:       uEmptyPod.DeepCopy(),
+			fedObject:          nil,
+			clusterObjs:        map[string]interface{}{"c1": uEmptyPod.DeepCopy(), "c2": uEmptyPod.DeepCopy()},
+			expectedErr:        nil,
+			expectedNeedUpdate: true,
+			expectedPodStatus: &corev1.PodStatus{
+				Phase:   corev1.PodPending,
+				Message: "Pod pending in clusters [c1,c2]",
+			},
+		},
+		{
+			name:         "1 failed pod, 1 pending pod, 1 running pod, 1 succeeded pod, need update",
+			sourceObject: uEmptyPod.DeepCopy(),
+			fedObject:    nil,
+			clusterObjs: map[string]interface{}{
+				"c1": uFailedPod.DeepCopy(),
+				"c2": uPendingPod.DeepCopy(),
+				"c3": uRunningPod.DeepCopy(),
+				"c4": uSucceededPod.DeepCopy(),
+			},
+			expectedErr:        nil,
+			expectedNeedUpdate: true,
+			expectedPodStatus: &corev1.PodStatus{
+				Phase:     corev1.PodFailed,
+				Message:   "Pod failed in clusters [c1], and pending in clusters [c2], and running in clusters [c3], and succeeded in clusters [c4]",
+				StartTime: &metav1.Time{Time: testTime.Add(-40 * time.Second)},
+				InitContainerStatuses: []corev1.ContainerStatus{
+					generateContainerStatus("failed-init (c1)", true, testTime),
+					generateContainerStatus("pending-init (c2)", true, testTime),
+					generateContainerStatus("running-init (c3)", true, testTime),
+					generateContainerStatus("succeeded-init (c4)", true, testTime),
+				},
+				ContainerStatuses: []corev1.ContainerStatus{
+					generateContainerStatus("failed (c1)", true, testTime),
+					generateContainerStatus("running (c3)", true, testTime),
+					generateContainerStatus("succeeded (c4)", true, testTime),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := klog.NewContext(context.Background(), klog.Background())
+			receiver := NewPodPlugin()
+
+			got, needUpdate, err := receiver.AggregateStatuses(ctx, tt.sourceObject, tt.fedObject, tt.clusterObjs, false)
+			if !errors.Is(err, tt.expectedErr) {
+				t.Fatalf("got error: %v, expectedErr: %v", err, tt.expectedErr)
+			}
+			// if err was expected, just pass it
+			if err != nil {
+				return
+			}
+			if needUpdate != tt.expectedNeedUpdate {
+				t.Fatalf("got needUpdate: %v, expectedNeedUpdate: %v", needUpdate, tt.expectedNeedUpdate)
+			}
+
+			uExpectedPodStatus, err := runtime.DefaultUnstructuredConverter.ToUnstructured(tt.expectedPodStatus)
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+
+			uGotStatus, _, _ := unstructured.NestedMap(got.Object, "status")
+			if !reflect.DeepEqual(uExpectedPodStatus, uGotStatus) {
+				t.Fatalf("got podStatus: %v, expected podStatus: %v", uGotStatus, uExpectedPodStatus)
+			}
+		})
+	}
+}
+
+func generateContainerStatus(name string, started bool, testTime time.Time) corev1.ContainerStatus {
+	return corev1.ContainerStatus{
+		Name: name,
+		State: corev1.ContainerState{
+			Running: &corev1.ContainerStateRunning{
+				StartedAt: metav1.NewTime(testTime),
+			},
+		},
+		Ready:        true,
+		RestartCount: 0,
+		Image:        "docker.io/library/nginx:alpine",
+		ImageID:      "docker.io/library/nginx@sha256:2e776a66a3556f001aba13431b26e448fe8acba277bf93d2ab1a785571a46d90",
+		ContainerID:  "containerd://664ec405ade16720f5dd08e827791a9bf9cd190b383f645c7d506136b64752ca",
+		Started:      &started,
+	}
+}


### PR DESCRIPTION
When the FTC of the pod and job enables `statusAggregation`, now we can get the aggregated status of job and pod on the native resources on the federation side.

For pods, InitContainerStatuses and ContainerStatuses are collected. The aggregated startTime depends on the earliest startTime in the member cluster pod, and the aggregated pod phase is generated by the following priorities:
1. If there is any failed pod, the aggregation phase is `Failed`
2. If there is any pending pod, or a pod whose status is empty, the aggregation phase is `Pending`
3. If there is any running pod, the aggregation phase is `Running`
4. If **all** pods are succeeded, the aggregation phase is `Succeeded`

For jobs, the sum of all Active, Succeeded and Failed pods will be collected. The aggregated startTime depends on the earliest startTime in the member cluster job. The aggregated job Condition is generated by the following priority:
1. If **all** the jobs are `Completed` or `Failed`, and there is any failed job, the aggregation status is `Failed`, and the completionTime is the time of the last completed job
2. If **all** the jobs are `Completed`, the aggregation status is `Completed`, and the completionTime is the time of the last completed job
3. Otherwise, the job is still in processing

Also, it shows some extra messages about how the job/pod works in the member cluster, which I think might be useful for developers or debuggers.

Here is an example result:

`kubectl get pod test-po -oyaml`
```yaml
apiVersion: v1
kind: Pod
metadata:
  annotations:
    kubeadmiral.io/scheduling: '{"generation":null,"fedGeneration":2,"placement":["kubeadmiral-member-1","kubeadmiral-member-2"]}'
    kubeadmiral.io/status: '{"clusters":[{"name":"kubeadmiral-member-1","generation":0},{"name":"kubeadmiral-member-2","generation":0}]}'
    kubeadmiral.io/syncing: '{"generation":null,"fedGeneration":2,"clusters":[{"name":"kubeadmiral-member-1","status":"OK"},{"name":"kubeadmiral-member-2","status":"OK"}]}'
  creationTimestamp: "2023-06-12T08:23:07Z"
  finalizers:
  - kubeadmiral.io/federate-controller
  labels:
    kubeadmiral.io/propagation-policy-name: pp-2cluster-duplicate
    run: test-po
  name: test-po
  namespace: default
  resourceVersion: "1349830"
  uid: 31348c96-0bf1-4cfa-8418-251616f55d2c
spec:
  automountServiceAccountToken: false
  containers:
  - image: nginx:alpine
    imagePullPolicy: IfNotPresent
    name: test-po
...
status:
  containerStatuses:
  - containerID: containerd://26bf95ca6d04e9c5d15cea130418f96740217db784898adeabb907e892e8c3a5
    image: docker.io/library/nginx:alpine
    imageID: docker.io/library/nginx@sha256:2e776a66a3556f001aba13431b26e448fe8acba277bf93d2ab1a785571a46d90
    lastState: {}
    name: test-po (kubeadmiral-member-2)
    ready: true
    restartCount: 0
    started: true
    state:
      running:
        startedAt: "2023-06-12T13:23:19Z"
  message: Pod pending in clusters [kubeadmiral-member-1], and running in clusters
    [kubeadmiral-member-2]
  phase: Pending
  startTime: "2023-06-12T13:23:18Z"
```

`kubectl get job test-job -oyaml`

```yaml
apiVersion: batch/v1
kind: Job
metadata:
  annotations:
    kubeadmiral.io/scheduling: '{"generation":null,"fedGeneration":3,"placement":["kubeadmiral-member-1","kubeadmiral-member-2"]}'
    kubeadmiral.io/status: '{"clusters":[{"name":"kubeadmiral-member-1","generation":0},{"name":"kubeadmiral-member-2","generation":0}]}'
    kubeadmiral.io/syncing: '{"generation":null,"fedGeneration":3,"clusters":[{"name":"kubeadmiral-member-1","status":"OK"},{"name":"kubeadmiral-member-2","status":"OK"}]}'
  creationTimestamp: "2023-06-12T14:01:01Z"
  finalizers:
  - kubeadmiral.io/federate-controller
  labels:
    app: test-job
    job-name: test-job
    kubeadmiral.io/override-policy-name: job-failed
    kubeadmiral.io/propagation-policy-name: pp-2cluster-duplicate
  name: test-job
  namespace: default
  resourceVersion: "1353660"
  uid: f2e7a03e-10d6-44c3-88b9-9f5c2075c796
spec:
  activeDeadlineSeconds: 300
  backoffLimit: 6
  completions: 3
  parallelism: 2
  selector:
    matchLabels:
      controller-uid: f2e7a03e-10d6-44c3-88b9-9f5c2075c796
  template:
    metadata:
      creationTimestamp: null
      labels:
        app: test-job
        controller-uid: f2e7a03e-10d6-44c3-88b9-9f5c2075c796
        job-name: test-job
    spec:
      containers:
      - args:
        - -c
        - date; echo running; sleep 60; date; echo done
        command:
        - /bin/sh
        image: nginx:alpine
        imagePullPolicy: IfNotPresent
...
status:
  completionTime: "2023-06-12T14:05:20Z"
  conditions:
  - lastProbeTime: "2023-06-12T14:05:30Z"
    lastTransitionTime: "2023-06-12T14:05:30Z"
    message: Job completed in clusters [kubeadmiral-member-2] and failed in member
      clusters [kubeadmiral-member-1]
    reason: Mixed
    status: "True"
    type: Failed
  failed: 8
  startTime: "2023-06-12T14:03:18Z"
  succeeded: 3
```