### PR TITLE
fix: GetClusterObject should return only managed objects

### DIFF
--- a/pkg/controllers/sync/controller.go
+++ b/pkg/controllers/sync/controller.go
@@ -58,6 +58,7 @@ import (
 	"github.com/kubewharf/kubeadmiral/pkg/controllers/util/eventsink"
 	finalizersutil "github.com/kubewharf/kubeadmiral/pkg/controllers/util/finalizers"
 	"github.com/kubewharf/kubeadmiral/pkg/controllers/util/history"
+	"github.com/kubewharf/kubeadmiral/pkg/controllers/util/managedlabel"
 	"github.com/kubewharf/kubeadmiral/pkg/controllers/util/pendingcontrollers"
 	schemautil "github.com/kubewharf/kubeadmiral/pkg/controllers/util/schema"
 	"github.com/kubewharf/kubeadmiral/pkg/controllers/util/sourcefeedback"
@@ -349,11 +350,11 @@ func (s *SyncController) reconcile(qualifiedName common.QualifiedName) (status w
 	if possibleOrphan {
 		apiResource := s.typeConfig.GetTargetType()
 		gvk := schemautil.APIResourceToGVK(&apiResource)
-		keyedLogger.WithValues("label", util.ManagedByKubeAdmiralLabelKey).
+		keyedLogger.WithValues("label", managedlabel.ManagedByKubeAdmiralLabelKey).
 			V(2).Info("Ensuring the removal of the label in member clusters")
 		err = s.removeManagedLabel(ctx, gvk, qualifiedName)
 		if err != nil {
-			keyedLogger.WithValues("label", util.ManagedByKubeAdmiralLabelKey).
+			keyedLogger.WithValues("label", managedlabel.ManagedByKubeAdmiralLabelKey).
 				Error(err, "Failed to remove the label from object in member clusters")
 			return worker.StatusError
 		}
@@ -754,11 +755,11 @@ func (s *SyncController) ensureDeletion(ctx context.Context, fedResource Federat
 				Error(err, "Failed to remove finalizer for federated object")
 			return worker.StatusError
 		}
-		keyedLogger.WithValues("label-name", util.ManagedByKubeAdmiralLabelKey).
+		keyedLogger.WithValues("label-name", managedlabel.ManagedByKubeAdmiralLabelKey).
 			V(2).Info("Removing managed label from resources previously managed by this federated object")
 		err = s.removeManagedLabel(ctx, fedResource.TargetGVK(), fedResource.TargetName())
 		if err != nil {
-			keyedLogger.WithValues("label-name", util.ManagedByKubeAdmiralLabelKey).
+			keyedLogger.WithValues("label-name", managedlabel.ManagedByKubeAdmiralLabelKey).
 				Error(err, "Failed to remove the label from all resources previously managed by this federated object")
 			return worker.StatusError
 		}
@@ -1160,7 +1161,7 @@ func (s *SyncController) reconcileCluster(qualifiedName common.QualifiedName) wo
 		runtimeclient.Limit(1),
 		runtimeclient.InNamespace(corev1.NamespaceAll),
 		runtimeclient.MatchingLabels{
-			util.ManagedByKubeAdmiralLabelKey: util.ManagedByKubeAdmiralLabelValue,
+			managedlabel.ManagedByKubeAdmiralLabelKey: managedlabel.ManagedByKubeAdmiralLabelValue,
 		},
 	)
 	if err == nil && len(objects.Items) > 0 {

--- a/pkg/controllers/sync/dispatch/checkunmanaged.go
+++ b/pkg/controllers/sync/dispatch/checkunmanaged.go
@@ -32,6 +32,7 @@ import (
 	"github.com/kubewharf/kubeadmiral/pkg/client/generic"
 	"github.com/kubewharf/kubeadmiral/pkg/controllers/common"
 	"github.com/kubewharf/kubeadmiral/pkg/controllers/util"
+	"github.com/kubewharf/kubeadmiral/pkg/controllers/util/managedlabel"
 )
 
 type CheckUnmanagedDispatcher interface {
@@ -90,7 +91,7 @@ func (d *checkUnmanagedDispatcherImpl) CheckRemovedOrUnlabeled(ctx context.Conte
 			keyedLogger.Error(fmt.Errorf("resource is pending deletion"), errLogMessage)
 			return false
 		}
-		if !util.HasManagedLabel(clusterObj) {
+		if !managedlabel.HasManagedLabel(clusterObj) {
 			return true
 		}
 		keyedLogger.Error(fmt.Errorf("resource still has the managed label"), errLogMessage)

--- a/pkg/controllers/sync/dispatch/managed.go
+++ b/pkg/controllers/sync/dispatch/managed.go
@@ -43,6 +43,7 @@ import (
 	"github.com/kubewharf/kubeadmiral/pkg/controllers/sync/status"
 	"github.com/kubewharf/kubeadmiral/pkg/controllers/util"
 	"github.com/kubewharf/kubeadmiral/pkg/controllers/util/annotation"
+	"github.com/kubewharf/kubeadmiral/pkg/controllers/util/managedlabel"
 	utilunstructured "github.com/kubewharf/kubeadmiral/pkg/controllers/util/unstructured"
 	"github.com/kubewharf/kubeadmiral/pkg/stats"
 )
@@ -389,7 +390,7 @@ func (d *managedDispatcherImpl) Create(ctx context.Context, clusterName string) 
 			op,
 			errors.Errorf("An update will be attempted instead of a creation due to an existing resource"),
 		)
-		if !util.HasManagedLabel(obj) {
+		if !managedlabel.HasManagedLabel(obj) {
 			// If the object was not managed by us, mark it as adopted.
 			annotation.AddAnnotation(obj, util.AdoptedAnnotation, common.AnnotationValueTrue)
 		}
@@ -405,11 +406,11 @@ func (d *managedDispatcherImpl) Update(ctx context.Context, clusterName string, 
 	const op = "update"
 	go d.dispatcher.clusterOperation(ctx, clusterName, op, func(client generic.Client) bool {
 		keyedLogger := klog.FromContext(ctx).WithValues("cluster-name", clusterName)
-		if util.IsExplicitlyUnmanaged(clusterObj) {
+		if managedlabel.IsExplicitlyUnmanaged(clusterObj) {
 			err := errors.Errorf(
 				"Unable to manage the object which has label %s: %s",
-				util.ManagedByKubeAdmiralLabelKey,
-				util.UnmanagedByKubeAdmiralLabelValue,
+				managedlabel.ManagedByKubeAdmiralLabelKey,
+				managedlabel.UnmanagedByKubeAdmiralLabelValue,
 			)
 			return d.recordOperationError(ctx, fedtypesv1a1.ManagedLabelFalse, clusterName, op, err)
 		}
@@ -491,11 +492,11 @@ func (d *managedDispatcherImpl) PatchAndKeepTemplate(
 	const op = "update"
 	go d.dispatcher.clusterOperation(ctx, clusterName, op, func(client generic.Client) bool {
 		keyedLogger := klog.FromContext(ctx).WithValues("cluster-name", clusterName)
-		if util.IsExplicitlyUnmanaged(clusterObj) {
+		if managedlabel.IsExplicitlyUnmanaged(clusterObj) {
 			err := errors.Errorf(
 				"Unable to manage the object which has label %s: %s",
-				util.ManagedByKubeAdmiralLabelKey,
-				util.UnmanagedByKubeAdmiralLabelValue,
+				managedlabel.ManagedByKubeAdmiralLabelKey,
+				managedlabel.UnmanagedByKubeAdmiralLabelValue,
 			)
 			return d.recordOperationError(ctx, fedtypesv1a1.ManagedLabelFalse, clusterName, op, err)
 		}

--- a/pkg/controllers/sync/dispatch/unmanaged.go
+++ b/pkg/controllers/sync/dispatch/unmanaged.go
@@ -37,6 +37,7 @@ import (
 	"github.com/kubewharf/kubeadmiral/pkg/controllers/common"
 	"github.com/kubewharf/kubeadmiral/pkg/controllers/util"
 	"github.com/kubewharf/kubeadmiral/pkg/controllers/util/finalizers"
+	"github.com/kubewharf/kubeadmiral/pkg/controllers/util/managedlabel"
 )
 
 const (
@@ -184,7 +185,7 @@ func (d *unmanagedDispatcherImpl) RemoveManagedLabel(ctx context.Context, cluste
 		// Avoid mutating the resource in the informer cache
 		updateObj := clusterObj.DeepCopy()
 
-		util.RemoveManagedLabel(updateObj)
+		managedlabel.RemoveManagedLabel(updateObj)
 		if _, err := removeRetainObjectFinalizer(updateObj); err != nil {
 			if d.recorder == nil {
 				wrappedErr := d.wrapOperationError(err, clusterName, op)

--- a/pkg/controllers/sync/resource.go
+++ b/pkg/controllers/sync/resource.go
@@ -44,6 +44,7 @@ import (
 	"github.com/kubewharf/kubeadmiral/pkg/controllers/util"
 	annotationutil "github.com/kubewharf/kubeadmiral/pkg/controllers/util/annotation"
 	"github.com/kubewharf/kubeadmiral/pkg/controllers/util/finalizers"
+	"github.com/kubewharf/kubeadmiral/pkg/controllers/util/managedlabel"
 	schemautil "github.com/kubewharf/kubeadmiral/pkg/controllers/util/schema"
 	utilunstructured "github.com/kubewharf/kubeadmiral/pkg/controllers/util/unstructured"
 )
@@ -324,7 +325,7 @@ func (r *federatedResource) ApplyOverrides(
 	// Ensure that resources managed by KubeFed always have the
 	// managed label.  The label is intended to be targeted by all the
 	// KubeFed controllers.
-	util.AddManagedLabel(obj)
+	managedlabel.AddManagedLabel(obj)
 
 	return nil
 }

--- a/pkg/controllers/util/federatedinformer.go
+++ b/pkg/controllers/util/federatedinformer.go
@@ -40,6 +40,7 @@ import (
 	fedcorev1a1 "github.com/kubewharf/kubeadmiral/pkg/apis/core/v1alpha1"
 	"github.com/kubewharf/kubeadmiral/pkg/client/generic"
 	"github.com/kubewharf/kubeadmiral/pkg/controllers/common"
+	"github.com/kubewharf/kubeadmiral/pkg/controllers/util"
 	"github.com/kubewharf/kubeadmiral/pkg/controllers/util/schema"
 )
 
@@ -670,6 +671,9 @@ func GetClusterObject(
 	}
 	if err != nil {
 		return nil, false, fmt.Errorf("failed to get object %s with client: %w", qualifedName.String(), err)
+	}
+	if !util.HasManagedLabel(clusterObj) {
+		return nil, false, nil
 	}
 
 	return clusterObj, true, nil

--- a/pkg/controllers/util/federatedinformer.go
+++ b/pkg/controllers/util/federatedinformer.go
@@ -41,7 +41,7 @@ import (
 	fedcorev1a1 "github.com/kubewharf/kubeadmiral/pkg/apis/core/v1alpha1"
 	"github.com/kubewharf/kubeadmiral/pkg/client/generic"
 	"github.com/kubewharf/kubeadmiral/pkg/controllers/common"
-	"github.com/kubewharf/kubeadmiral/pkg/controllers/util"
+	"github.com/kubewharf/kubeadmiral/pkg/controllers/util/managedlabel"
 	"github.com/kubewharf/kubeadmiral/pkg/controllers/util/schema"
 )
 
@@ -676,7 +676,7 @@ func GetClusterObject(
 	if err != nil {
 		return nil, false, fmt.Errorf("failed to get object %s with client: %w", qualifedName.String(), err)
 	}
-	if !util.HasManagedLabel(clusterObj) {
+	if !managedlabel.HasManagedLabel(clusterObj) {
 		return nil, false, nil
 	}
 

--- a/pkg/controllers/util/federatedinformer.go
+++ b/pkg/controllers/util/federatedinformer.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	pkgruntime "k8s.io/apimachinery/pkg/runtime"
@@ -667,6 +668,9 @@ func GetClusterObject(
 
 	err = client.Get(ctx, clusterObj, qualifedName.Namespace, qualifedName.Name)
 	if apierrors.IsNotFound(err) {
+		return nil, false, nil
+	}
+	if meta.IsNoMatchError(err) {
 		return nil, false, nil
 	}
 	if err != nil {

--- a/pkg/controllers/util/managedlabel/managedlabel.go
+++ b/pkg/controllers/util/managedlabel/managedlabel.go
@@ -18,7 +18,7 @@ This file may have been modified by The KubeAdmiral Authors
 are Copyright 2023 The KubeAdmiral Authors.
 */
 
-package util
+package managedlabel
 
 import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"

--- a/pkg/controllers/util/resourceinformer.go
+++ b/pkg/controllers/util/resourceinformer.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
+	"github.com/kubewharf/kubeadmiral/pkg/controllers/util/managedlabel"
 	"github.com/kubewharf/kubeadmiral/pkg/stats"
 )
 
@@ -75,7 +76,7 @@ func NewManagedResourceInformer(
 	extraTags map[string]string,
 	metrics stats.Metrics,
 ) (cache.Store, cache.Controller) {
-	labelSelector := labels.Set(map[string]string{ManagedByKubeAdmiralLabelKey: ManagedByKubeAdmiralLabelValue}).
+	labelSelector := labels.Set(map[string]string{managedlabel.ManagedByKubeAdmiralLabelKey: managedlabel.ManagedByKubeAdmiralLabelValue}).
 		AsSelector().
 		String()
 	return newResourceInformer(


### PR DESCRIPTION
`GetClusterObject` has a bug where if it defaults to getting directly from the cluster, it may return unmanaged objects. This causes the sync, status and status aggregation controllers to not work correctly.

Additional changes:

* functions dealing with managed label is now moved to a new package
* additionally handle `NoMatch` error (return nil when requested object's GVK is not found)