### PR TITLE
feat: implement apply later for propagation policy

### DIFF
--- a/config/crds/core.kubeadmiral.io_clusterpropagationpolicies.yaml
+++ b/config/crds/core.kubeadmiral.io_clusterpropagationpolicies.yaml
@@ -36,6 +36,13 @@ spec:
                   maxLength: 63
             spec:
               properties:
+                applyPolicy:
+                  default: ApplyNow
+                  description: 'ApplyPolicy determines when the policy applied for scheduling. Available values: ApplyNow (default behavior), ApplyLater.'
+                  enum:
+                    - ApplyNow
+                    - ApplyLater
+                  type: string
                 autoMigration:
                   description: Configures behaviors related to auto migration. If absent, auto migration will be disabled.
                   properties:

--- a/config/crds/core.kubeadmiral.io_propagationpolicies.yaml
+++ b/config/crds/core.kubeadmiral.io_propagationpolicies.yaml
@@ -36,6 +36,13 @@ spec:
                   maxLength: 63
             spec:
               properties:
+                applyPolicy:
+                  default: ApplyNow
+                  description: 'ApplyPolicy determines when the policy applied for scheduling. Available values: ApplyNow (default behavior), ApplyLater.'
+                  enum:
+                    - ApplyNow
+                    - ApplyLater
+                  type: string
                 autoMigration:
                   description: Configures behaviors related to auto migration. If absent, auto migration will be disabled.
                   properties:

--- a/pkg/apis/core/v1alpha1/types_common.go
+++ b/pkg/apis/core/v1alpha1/types_common.go
@@ -75,3 +75,16 @@ const (
 	ClusterSelectorOpGt           ClusterSelectorOperator = "Gt"
 	ClusterSelectorOpLt           ClusterSelectorOperator = "Lt"
 )
+
+// ApplyPolicy determines the policy used by the scheduler when scheduling federated objects.
+// +kubebuilder:validation:Enum=ApplyNow;ApplyLater
+type ApplyPolicy string
+
+const (
+	// ApplyNow means the policy will take effect immediately for all matched objects.
+	ApplyNow ApplyPolicy = "ApplyNow"
+
+	// ApplyLater means the policy will take effect for all matched objects on next
+	// objects' updates or new created objects.
+	ApplyLater ApplyPolicy = "ApplyLater"
+)

--- a/pkg/apis/core/v1alpha1/types_propagationpolicy.go
+++ b/pkg/apis/core/v1alpha1/types_propagationpolicy.go
@@ -107,6 +107,12 @@ type PropagationPolicySpec struct {
 	// Default set via a post-generation patch.
 	// See patch file for details.
 	ReplicaRescheduling *ReplicaRescheduling `json:"replicaRescheduling,omitempty"`
+
+	// ApplyPolicy determines when the policy applied for scheduling.
+	// Available values: ApplyNow (default behavior), ApplyLater.
+	// +optional
+	// +kubebuilder:default=ApplyNow
+	ApplyPolicy ApplyPolicy `json:"applyPolicy"`
 }
 
 type PropagationPolicyStatus struct {

--- a/pkg/controllers/common/constants.go
+++ b/pkg/controllers/common/constants.go
@@ -114,6 +114,10 @@ const (
 	SourceGenerationAnnotation    = DefaultPrefix + "source-generation"
 	FederatedGenerationAnnotation = DefaultPrefix + "federated-generation"
 
+	LastAppliedPropagationPolicyGenerationAnnotation = DefaultPrefix + "last-applied-propagation-policy-generation"
+	ObservedPropagationPolicyGenerationAnnotation    = DefaultPrefix + "observed-propagation-policy-generation"
+	LastAppliedTemplateHashAnnotation                = DefaultPrefix + "last-applied-template-hash"
+
 	// The following annotations control the behavior of Kubeadmiral controllers.
 
 	NoSchedulingAnnotation = DefaultPrefix + "no-scheduling"


### PR DESCRIPTION
Three new annotations are introduced on fedObj to implement the `ApplyLater` feature. Specifically: if a resource is associated with a policy, three annotations will be marked on its fedObj, namely: 
* `kubeadmiral.io/last-applied-propagation-policy-generation` Its value indicates the generation version of the policy that took effect last time.
* `kubeadmiral.io/last -applied-template-hash` Its value represents the hash value of the `fedObj.spec.template` content that took effect last time.
* `kubeadmiral.io/observed-propagation-policy-generation` Its value represents the generation version of the policy observed by the scheduler.

If `policy.spec.applyPolicy = ApplyLater`, then the change of the policy will not cause the change of the `PolicyGeneration` in `schedulingTriggers`, only the change of the original resource will make the `PolicyGeneration` change, thus triggering the rescheduling based on the policy. Therefore, `kubeadmiral.io/last-applied-template-hash` is introduced to observe whether resources change, and `kubeadmiral.io/last-applied-propagation-policy-generation` is introduced to retain last applied `PolicyGeneration` in `schedulingTriggers`. 

And `kubeadmiral.io/observed-propagation-policy-generation` is introduced to easily observe whether the current resource is already the latest policy result from fedObj: `last-applied-propagation-policy-generation` == `observed-propagation-policy-generation`, the latest policy has been applied, otherwise the latest policy has not been applied.
 
 If `policy.spec.applyPolicy = ApplyNow` (this is the default behavior), the change of policy will change the `PolicyGeneration` in `schedulingTriggers` and then trigger the scheduler rescheduling.
 
When a policy is removed from a resource, the above three annotations will be removed on its fedObj too.

**Note:** The first time a resource is associated with a new policy, scheduling will be triggered `immediately` anyway.

Here is an example when `policy.spec.applyPolicy = ApplyLater`:

``` yaml
apiVersion: types.kubeadmiral.io/v1alpha1
kind: FederatedConfigMap
metadata:
  annotations:
    federate.controller.kubeadmiral.io/observed-annotations: '|kubeadmiral.io/scheduling,kubeadmiral.io/syncing'
    federate.controller.kubeadmiral.io/observed-labels: kubeadmiral.io/propagation-policy-name|aa,aaa
    federate.controller.kubeadmiral.io/template-generator-merge-patch: '{"metadata":{"annotations":{"kubeadmiral.io/scheduling":null,"kubeadmiral.io/syncing":null},"creationTimestamp":null,"finalizers":null,"labels":{"kubeadmiral.io/propagation-policy-name":null},"managedFields":null,"resourceVersion":null,"uid":null}}'
    internal.kubeadmiral.io/enable-follower-scheduling: "true"
    kubeadmiral.io/federated-object: "1"
    kubeadmiral.io/last-applied-propagation-policy-generation: "7"       # policy generation
    kubeadmiral.io/last-applied-template-hash: "3942948866"              # template hash
    kubeadmiral.io/observed-propagation-policy-generation: "8"           # latest policy generation
    kubeadmiral.io/pending-controllers: '[]'
    kubeadmiral.io/scheduling-trigger-hash: "2359891339"
    kubeadmiral.io/syncing: '{"generation":null,"fedGeneration":14,"clusters":[{"name":"kubeadmiral-member-1","status":"OK"},{"name":"kubeadmiral-member-2","status":"OK"}]}'
    lastSyncSuccessGeneration: "14"
    syncSuccessTimestamp: "2023-06-28T09:40:38.208825293Z"
...
```

