### PR TITLE
fix: use metav1.Object instead of runtime.Object for more ergonomic annotation handling

### DIFF
--- a/pkg/controllers/util/annotation/annotation.go
+++ b/pkg/controllers/util/annotation/annotation.go
@@ -20,26 +20,21 @@ import (
 	"fmt"
 	"reflect"
 
-	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/runtime"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
-	SyncSuccessTimestamp       = "syncSuccessTimestamp"
-	LastGeneration             = "lastGeneration"
+	SyncSuccessTimestamp      = "syncSuccessTimestamp"
+	LastGeneration            = "lastGeneration"
 	LastSyncSuccessGeneration = "lastSyncSuccessGeneration"
 )
 
 // HasAnnotationKey returns true if the given object has the given annotation key in its ObjectMeta.
-func HasAnnotationKey(obj runtime.Object, key string) (bool, error) {
+func HasAnnotationKey(obj metav1.Object, key string) (bool, error) {
 	if IsNilPointer(obj) {
 		return false, fmt.Errorf("object(%T) is nil pointer", obj)
 	}
-	accessor, err := meta.Accessor(obj)
-	if err != nil {
-		return false, err
-	}
-	annotations := accessor.GetAnnotations()
+	annotations := obj.GetAnnotations()
 	if annotations == nil {
 		return false, nil
 	}
@@ -48,15 +43,11 @@ func HasAnnotationKey(obj runtime.Object, key string) (bool, error) {
 }
 
 // HasAnnotationKeyValue returns true if the given object has the given annotation key and value in its ObjectMeta.
-func HasAnnotationKeyValue(obj runtime.Object, key, value string) (bool, error) {
+func HasAnnotationKeyValue(obj metav1.Object, key, value string) (bool, error) {
 	if IsNilPointer(obj) {
 		return false, fmt.Errorf("object(%T) is nil pointer", obj)
 	}
-	accessor, err := meta.Accessor(obj)
-	if err != nil {
-		return false, err
-	}
-	annotations := accessor.GetAnnotations()
+	annotations := obj.GetAnnotations()
 	if annotations == nil {
 		return false, nil
 	}
@@ -67,7 +58,7 @@ func HasAnnotationKeyValue(obj runtime.Object, key, value string) (bool, error) 
 // AddAnnotation adds the given annotation key and value to the given objects ObjectMeta,
 // and overwrites the annotation value if it already exists.
 // Returns true if the object was updated.
-func AddAnnotation(obj runtime.Object, key, value string) (bool, error) {
+func AddAnnotation(obj metav1.Object, key, value string) (bool, error) {
 	if IsNilPointer(obj) {
 		return false, fmt.Errorf("object(%T) is nil pointer", obj)
 	}
@@ -76,10 +67,6 @@ func AddAnnotation(obj runtime.Object, key, value string) (bool, error) {
 		return false, fmt.Errorf("key is a empty string.")
 	}
 
-	accessor, err := meta.Accessor(obj)
-	if err != nil {
-		return false, err
-	}
 	has, err := HasAnnotationKeyValue(obj, key, value)
 	if has && err == nil {
 		return false, nil
@@ -87,24 +74,20 @@ func AddAnnotation(obj runtime.Object, key, value string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	annotations := accessor.GetAnnotations()
+	annotations := obj.GetAnnotations()
 	if annotations == nil {
 		annotations = make(map[string]string)
 	}
 	annotations[key] = value
-	accessor.SetAnnotations(annotations)
+	obj.SetAnnotations(annotations)
 	return true, nil
 }
 
 // RemoveAnnotation removes the given annotation key from the given objects ObjectMeta.
 // Returns true if the object was updated.
-func RemoveAnnotation(obj runtime.Object, key string) (bool, error) {
+func RemoveAnnotation(obj metav1.Object, key string) (bool, error) {
 	if IsNilPointer(obj) {
 		return false, fmt.Errorf("object(%T) is nil pointer", obj)
-	}
-	accessor, err := meta.Accessor(obj)
-	if err != nil {
-		return false, err
 	}
 	has, err := HasAnnotationKey(obj, key)
 	if !has && err == nil {
@@ -114,13 +97,13 @@ func RemoveAnnotation(obj runtime.Object, key string) (bool, error) {
 		return false, err
 	}
 
-	annotations := accessor.GetAnnotations()
+	annotations := obj.GetAnnotations()
 	if annotations == nil {
 		return false, nil
 	}
 
 	delete(annotations, key)
-	accessor.SetAnnotations(annotations)
+	obj.SetAnnotations(annotations)
 	return true, nil
 }
 

--- a/pkg/controllers/util/annotation/annotation_test.go
+++ b/pkg/controllers/util/annotation/annotation_test.go
@@ -23,10 +23,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/runtime"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func newObj(annotation map[string]string) runtime.Object {
+func newObj(annotation map[string]string) metav1.Object {
 	pod := corev1.Pod{}
 	pod.ObjectMeta.Annotations = annotation
 	return &pod
@@ -34,7 +34,7 @@ func newObj(annotation map[string]string) runtime.Object {
 
 func TestHasAnnotationKey(t *testing.T) {
 	testCases := []struct {
-		obj        runtime.Object
+		obj        metav1.Object
 		annotation string
 		result     bool
 	}{
@@ -82,7 +82,7 @@ func TestHasAnnotationKey(t *testing.T) {
 
 func TestHasAnnotationKeyValue(t *testing.T) {
 	testCases := []struct {
-		obj    runtime.Object
+		obj    metav1.Object
 		key    string
 		value  string
 		result bool
@@ -149,7 +149,7 @@ func TestHasAnnotationKeyValue(t *testing.T) {
 
 func TestAddAnnotation(t *testing.T) {
 	testCases := []struct {
-		obj            runtime.Object
+		obj            metav1.Object
 		key            string
 		value          string
 		isUpdated      bool
@@ -231,7 +231,7 @@ func TestAddAnnotation(t *testing.T) {
 
 func TestRemoveAnnotation(t *testing.T) {
 	testCases := []struct {
-		obj            runtime.Object
+		obj            metav1.Object
 		key            string
 		isUpdated      bool
 		newAnnotations map[string]string

--- a/pkg/controllers/util/sourcefeedback/util.go
+++ b/pkg/controllers/util/sourcefeedback/util.go
@@ -19,13 +19,13 @@ package sourcefeedback
 import (
 	"encoding/json"
 
-	"k8s.io/apimachinery/pkg/runtime"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 
 	"github.com/kubewharf/kubeadmiral/pkg/controllers/util/annotation"
 )
 
-func setAnnotation(object runtime.Object, key string, value interface{}, hasChanged *bool) {
+func setAnnotation(object metav1.Object, key string, value interface{}, hasChanged *bool) {
 	jsonBuf, err := json.Marshal(value)
 	if err != nil {
 		klog.Errorf("Cannot marshal JSON: %v", err)


### PR DESCRIPTION
related to #99 