### PR TITLE
fix: add pod informer for auto-migration

### DIFF
--- a/pkg/controllers/automigration/plugins/plugins.go
+++ b/pkg/controllers/automigration/plugins/plugins.go
@@ -40,6 +40,12 @@ type Plugin interface {
 		obj *unstructured.Unstructured,
 		handle ClusterHandle,
 	) ([]*corev1.Pod, error)
+
+	GetTargetObjectFromPod(
+		ctx context.Context,
+		pod *corev1.Pod,
+		handle ClusterHandle,
+	) (obj *unstructured.Unstructured, found bool, err error)
 }
 
 var nativePlugins = map[schema.GroupVersionResource]Plugin{

--- a/pkg/controllers/common/constants.go
+++ b/pkg/controllers/common/constants.go
@@ -46,6 +46,7 @@ const (
 	PersistentVolumeKind      = "PersistentVolume"
 	PersistentVolumeClaimKind = "PersistentVolumeClaim"
 	PodKind                   = "Pod"
+	ReplicaSetKind            = "ReplicaSet"
 )
 
 // The following consts are spec fields used to interact with unstructured resources


### PR DESCRIPTION
Add pod informer triggers for auto-migration so that the auto-migration controller can find resources that need to be migrated. If the scheduled condition of the pod changes, and the resource to which the pod belongs is the target resource managed by admiral, then the pod will trigger auto-migration of the target resource.

 In order to find out the target resource to which the pod belongs, auto-migration plugin interface has been changed. 

Currently, two cluster informers are used, which will be modified after the controller is refactored to reduce duplication of work.