### PR TITLE
feat: add `kubeadmiral.io/disable-following` annotation to control the scheduling behavior of follower resources.

### DIFF
--- a/pkg/controllers/common/constants.go
+++ b/pkg/controllers/common/constants.go
@@ -125,6 +125,8 @@ const (
 	FollowersAnnotation = DefaultPrefix + "followers"
 	// EnableFollowerSchedulingAnnotation indicates whether follower scheduling should be enabled for the leader object.
 	EnableFollowerSchedulingAnnotation = InternalPrefix + "enable-follower-scheduling"
+	// DisableFollowingAnnotation indicates whether follower scheduling should be disabled for the follower object.
+	DisableFollowingAnnotation = DefaultPrefix + "disable-following"
 
 	// When a pod remains unschedulable beyond this threshold, it becomes eligible for automatic migration.
 	PodUnschedulableThresholdAnnotation = InternalPrefix + "pod-unschedulable-threshold"

--- a/pkg/controllers/federate/util.go
+++ b/pkg/controllers/federate/util.go
@@ -230,6 +230,7 @@ var (
 		common.NoSchedulingAnnotation,
 		scheduler.FollowsObjectAnnotation,
 		common.FollowersAnnotation,
+		common.DisableFollowingAnnotation,
 	)
 
 	// TODO: Do we need to specify the internal annotations here?


### PR DESCRIPTION
#### What is the problem with follower scheduling?
We may encounter scalability problems if a follower resource (e.g.: confimap) is automatically mounted on all deployments. This could result in too much information about the leader-follower relationship being kept on the follower resource.

#### What this PR does?
If the follower resource is annotated with `kubeadmiral.io/disable-following="true"`, the resource will not follow any leader resources for scheduling.
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  annotations:
    kubeadmiral.io/disable-following: "true"
  name: echo-server
  namespace: default
data: {}
```