### PR TITLE
feat: informer manager ftc update handlers

### DIFF
--- a/pkg/util/informermanager/informermanager.go
+++ b/pkg/util/informermanager/informermanager.go
@@ -281,11 +281,13 @@ func (m *informerManager) processFTCDeletionUnlocked(ctx context.Context, ftcNam
 	delete(m.eventHandlerRegistrations, ftcName)
 
 	lastObservedFTC := m.lastObservedFTCs[ftcName]
-	for _, handler := range m.ftcUpdateHandlers {
-		handler(lastObservedFTC, nil)
+	if lastObservedFTC != nil {
+		for _, handler := range m.ftcUpdateHandlers {
+			handler(lastObservedFTC, nil)
+		}
 	}
-
 	delete(m.lastObservedFTCs, ftcName)
+
 	m.initialFTCs.Delete(ftcName)
 
 	return nil

--- a/pkg/util/informermanager/informermanager.go
+++ b/pkg/util/informermanager/informermanager.go
@@ -25,6 +25,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
@@ -51,8 +52,10 @@ type informerManager struct {
 	ftcInformer              fedcorev1a1informers.FederatedTypeConfigInformer
 
 	eventHandlerGenerators []*EventHandlerGenerator
+	ftcUpdateHandlers      []FTCUpdateHandler
 
-	gvkMapping *bijection.Bijection[string, schema.GroupVersionKind]
+	initialFTCs sets.Set[string]
+	gvkMapping  *bijection.Bijection[string, schema.GroupVersionKind]
 
 	lastObservedFTCs          map[string]*fedcorev1a1.FederatedTypeConfig
 	informers                 map[string]informers.GenericInformer
@@ -71,10 +74,13 @@ func NewInformerManager(
 	manager := &informerManager{
 		lock:                      sync.RWMutex{},
 		started:                   false,
+		shutdown:                  false,
 		client:                    client,
 		informerTweakListOptions:  informerTweakListOptions,
 		ftcInformer:               ftcInformer,
 		eventHandlerGenerators:    []*EventHandlerGenerator{},
+		ftcUpdateHandlers:         []FTCUpdateHandler{},
+		initialFTCs:               sets.New[string](),
 		gvkMapping:                bijection.NewBijection[string, schema.GroupVersionKind](),
 		lastObservedFTCs:          map[string]*fedcorev1a1.FederatedTypeConfig{},
 		informers:                 map[string]informers.GenericInformer{},
@@ -200,12 +206,17 @@ func (m *informerManager) processFTC(
 		ctx, cancel := context.WithCancel(ctx)
 		go informer.Informer().Run(ctx.Done())
 
-		m.lastObservedFTCs[ftcName] = ftc
 		m.informers[ftcName] = informer
 		m.informerCancelFuncs[ftcName] = cancel
 		m.eventHandlerRegistrations[ftcName] = map[*EventHandlerGenerator]cache.ResourceEventHandlerRegistration{}
 		m.lastAppliedFTCsCache[ftcName] = map[*EventHandlerGenerator]*fedcorev1a1.FederatedTypeConfig{}
 	}
+
+	for _, handler := range m.ftcUpdateHandlers {
+		handler(m.lastObservedFTCs[ftcName], ftc)
+	}
+	m.lastObservedFTCs[ftcName] = ftc
+	m.initialFTCs.Delete(ftcName)
 
 	if !informer.Informer().HasSynced() {
 		logger.V(3).Info("Informer for FederatedTypeConfig not synced, will not register event handlers yet")
@@ -265,10 +276,17 @@ func (m *informerManager) processFTCDeletionUnlocked(ctx context.Context, ftcNam
 
 	m.gvkMapping.DeleteT1(ftcName)
 
-	delete(m.lastObservedFTCs, ftcName)
 	delete(m.informers, ftcName)
 	delete(m.informerCancelFuncs, ftcName)
 	delete(m.eventHandlerRegistrations, ftcName)
+
+	lastObservedFTC := m.lastObservedFTCs[ftcName]
+	for _, handler := range m.ftcUpdateHandlers {
+		handler(lastObservedFTC, nil)
+	}
+
+	delete(m.lastObservedFTCs, ftcName)
+	m.initialFTCs.Delete(ftcName)
 
 	return nil
 }
@@ -282,6 +300,18 @@ func (m *informerManager) AddEventHandlerGenerator(generator *EventHandlerGenera
 	}
 
 	m.eventHandlerGenerators = append(m.eventHandlerGenerators, generator)
+	return nil
+}
+
+func (m *informerManager) AddFTCUpdateHandler(handler FTCUpdateHandler) error {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	if m.started {
+		return fmt.Errorf("failed to add FTCUpdateHandler: InformerManager is already started")
+	}
+
+	m.ftcUpdateHandlers = append(m.ftcUpdateHandlers, handler)
 	return nil
 }
 
@@ -326,7 +356,9 @@ func (m *informerManager) GetResourceFTC(gvk schema.GroupVersionKind) (*fedcorev
 }
 
 func (m *informerManager) HasSynced() bool {
-	return m.ftcInformer.Informer().HasSynced()
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+	return m.ftcInformer.Informer().HasSynced() && len(m.initialFTCs) == 0
 }
 
 func (m *informerManager) Start(ctx context.Context) {
@@ -344,9 +376,16 @@ func (m *informerManager) Start(ctx context.Context) {
 
 	m.started = true
 
-	if !cache.WaitForCacheSync(ctx.Done(), m.HasSynced) {
+	if !cache.WaitForCacheSync(ctx.Done(), m.ftcInformer.Informer().HasSynced) {
 		logger.Error(nil, "Failed to wait for InformerManager cache sync")
 		return
+	}
+
+	// Populate the intial snapshot of FTCs
+
+	ftcs := m.ftcInformer.Informer().GetStore().List()
+	for _, ftc := range ftcs {
+		m.initialFTCs.Insert(ftc.(*fedcorev1a1.FederatedTypeConfig).GetName())
 	}
 
 	go wait.UntilWithContext(ctx, m.worker, 0)

--- a/pkg/util/informermanager/informermanager_test.go
+++ b/pkg/util/informermanager/informermanager_test.go
@@ -55,13 +55,20 @@ func TestInformerManager(t *testing.T) {
 		defaultFTCs := []*fedcorev1a1.FederatedTypeConfig{deploymentFTC, configmapFTC, secretFTC}
 		defaultObjs := []*unstructured.Unstructured{}
 		generators := []*EventHandlerGenerator{}
+		handlers := []FTCUpdateHandler{}
 
 		ctx, cancel := context.WithCancel(ctx)
-		manager, _, _ := bootstrapInformerManagerWithFakeClients(g, ctx, defaultFTCs, defaultObjs, generators)
+		manager, _, _ := bootstrapInformerManagerWithFakeClients(g, ctx, defaultFTCs, defaultObjs, generators, handlers)
 		defer func() {
 			cancel()
 			_ = wait.PollInfinite(time.Millisecond, func() (done bool, err error) { return manager.IsShutdown(), nil })
 		}()
+
+		ctxWithTimeout, timeoutCancel := context.WithTimeout(ctx, time.Second)
+		defer timeoutCancel()
+		if !cache.WaitForCacheSync(ctxWithTimeout.Done(), manager.HasSynced) {
+			g.Fail("Timed out waiting for InformerManager cache sync")
+		}
 
 		// 2. Verify that the GVK mapping for each FTC is eventually available
 
@@ -91,13 +98,27 @@ func TestInformerManager(t *testing.T) {
 		defaultFTCs := []*fedcorev1a1.FederatedTypeConfig{}
 		defaultObjs := []*unstructured.Unstructured{}
 		generators := []*EventHandlerGenerator{}
+		handlers := []FTCUpdateHandler{}
 
 		ctx, cancel := context.WithCancel(ctx)
-		manager, _, fedClient := bootstrapInformerManagerWithFakeClients(g, ctx, defaultFTCs, defaultObjs, generators)
+		manager, _, fedClient := bootstrapInformerManagerWithFakeClients(
+			g,
+			ctx,
+			defaultFTCs,
+			defaultObjs,
+			generators,
+			handlers,
+		)
 		defer func() {
 			cancel()
 			_ = wait.PollInfinite(time.Millisecond, func() (done bool, err error) { return manager.IsShutdown(), nil })
 		}()
+
+		ctxWithTimeout, timeoutCancel := context.WithTimeout(ctx, time.Second)
+		defer timeoutCancel()
+		if !cache.WaitForCacheSync(ctxWithTimeout.Done(), manager.HasSynced) {
+			g.Fail("Timed out waiting for InformerManager cache sync")
+		}
 
 		ftc := daemonsetFTC
 		gvk := ftc.GetSourceTypeGVK()
@@ -133,13 +154,20 @@ func TestInformerManager(t *testing.T) {
 		defaultFTCs := []*fedcorev1a1.FederatedTypeConfig{deploymentFTC, configmapFTC, secretFTC}
 		defaultObjs := []*unstructured.Unstructured{}
 		generators := []*EventHandlerGenerator{}
+		handlers := []FTCUpdateHandler{}
 
 		ctx, cancel := context.WithCancel(ctx)
-		manager, _, _ := bootstrapInformerManagerWithFakeClients(g, ctx, defaultFTCs, defaultObjs, generators)
+		manager, _, _ := bootstrapInformerManagerWithFakeClients(g, ctx, defaultFTCs, defaultObjs, generators, handlers)
 		defer func() {
 			cancel()
 			_ = wait.PollInfinite(time.Millisecond, func() (done bool, err error) { return manager.IsShutdown(), nil })
 		}()
+
+		ctxWithTimeout, timeoutCancel := context.WithTimeout(ctx, time.Second)
+		defer timeoutCancel()
+		if !cache.WaitForCacheSync(ctxWithTimeout.Done(), manager.HasSynced) {
+			g.Fail("Timed out waiting for InformerManager cache sync")
+		}
 
 		// 2. Verify that the listers for each FTC is eventually available
 
@@ -171,13 +199,27 @@ func TestInformerManager(t *testing.T) {
 		defaultFTCs := []*fedcorev1a1.FederatedTypeConfig{}
 		defaultObjs := []*unstructured.Unstructured{}
 		generators := []*EventHandlerGenerator{}
+		handlers := []FTCUpdateHandler{}
 
 		ctx, cancel := context.WithCancel(ctx)
-		manager, _, fedClient := bootstrapInformerManagerWithFakeClients(g, ctx, defaultFTCs, defaultObjs, generators)
+		manager, _, fedClient := bootstrapInformerManagerWithFakeClients(
+			g,
+			ctx,
+			defaultFTCs,
+			defaultObjs,
+			generators,
+			handlers,
+		)
 		defer func() {
 			cancel()
 			_ = wait.PollInfinite(time.Millisecond, func() (done bool, err error) { return manager.IsShutdown(), nil })
 		}()
+
+		ctxWithTimeout, timeoutCancel := context.WithTimeout(ctx, time.Second)
+		defer timeoutCancel()
+		if !cache.WaitForCacheSync(ctxWithTimeout.Done(), manager.HasSynced) {
+			g.Fail("Timed out waiting for InformerManager cache sync")
+		}
 
 		ftc := daemonsetFTC
 		gvk := ftc.GetSourceTypeGVK()
@@ -231,6 +273,7 @@ func TestInformerManager(t *testing.T) {
 				Generator: neverRegistered.GenerateEventHandler,
 			},
 		}
+		handlers := []FTCUpdateHandler{}
 
 		ctx, cancel := context.WithCancel(ctx)
 		manager, dynamicClient, _ := bootstrapInformerManagerWithFakeClients(
@@ -239,11 +282,18 @@ func TestInformerManager(t *testing.T) {
 			defaultFTCs,
 			defaultObjs,
 			generators,
+			handlers,
 		)
 		defer func() {
 			cancel()
 			_ = wait.PollInfinite(time.Millisecond, func() (done bool, err error) { return manager.IsShutdown(), nil })
 		}()
+
+		ctxWithTimeout, timeoutCancel := context.WithTimeout(ctx, time.Second)
+		defer timeoutCancel()
+		if !cache.WaitForCacheSync(ctxWithTimeout.Done(), manager.HasSynced) {
+			g.Fail("Timed out waiting for InformerManager cache sync")
+		}
 
 		// 2. Verify alwaysRegistered is eventually registered for all existing FTCs.
 
@@ -328,6 +378,7 @@ func TestInformerManager(t *testing.T) {
 				Generator: neverRegistered.GenerateEventHandler,
 			},
 		}
+		handlers := []FTCUpdateHandler{}
 
 		ctx, cancel := context.WithCancel(ctx)
 		manager, dynamicClient, fedClient := bootstrapInformerManagerWithFakeClients(
@@ -336,11 +387,18 @@ func TestInformerManager(t *testing.T) {
 			defaultFTCs,
 			defaultObjs,
 			generators,
+			handlers,
 		)
 		defer func() {
 			cancel()
 			_ = wait.PollInfinite(time.Millisecond, func() (done bool, err error) { return manager.IsShutdown(), nil })
 		}()
+
+		ctxWithTimeout, timeoutCancel := context.WithTimeout(ctx, time.Second)
+		defer timeoutCancel()
+		if !cache.WaitForCacheSync(ctxWithTimeout.Done(), manager.HasSynced) {
+			g.Fail("Timed out waiting for InformerManager cache sync")
+		}
 
 		// 2. Verify that alwaysRegistered is not registered initially for daemonset
 
@@ -426,9 +484,17 @@ func TestInformerManager(t *testing.T) {
 		defaultFTCs := []*fedcorev1a1.FederatedTypeConfig{ftc}
 		defaultObjs := []*unstructured.Unstructured{}
 		generators := []*EventHandlerGenerator{generator}
+		handlers := []FTCUpdateHandler{}
 
 		ctx, cancel := context.WithCancel(ctx)
-		manager, _, fedClient := bootstrapInformerManagerWithFakeClients(g, ctx, defaultFTCs, defaultObjs, generators)
+		manager, _, fedClient := bootstrapInformerManagerWithFakeClients(
+			g,
+			ctx,
+			defaultFTCs,
+			defaultObjs,
+			generators,
+			handlers,
+		)
 		defer func() {
 			cancel()
 			_ = wait.PollInfinite(time.Millisecond, func() (done bool, err error) { return manager.IsShutdown(), nil })
@@ -469,6 +535,7 @@ func TestInformerManager(t *testing.T) {
 		defaultFTCs := []*fedcorev1a1.FederatedTypeConfig{ftc}
 		defaultObjs := []*unstructured.Unstructured{dp1}
 		generators := []*EventHandlerGenerator{generator}
+		handlers := []FTCUpdateHandler{}
 
 		ctx, cancel := context.WithCancel(ctx)
 		manager, dynamicClient, fedClient := bootstrapInformerManagerWithFakeClients(
@@ -477,11 +544,18 @@ func TestInformerManager(t *testing.T) {
 			defaultFTCs,
 			defaultObjs,
 			generators,
+			handlers,
 		)
 		defer func() {
 			cancel()
 			_ = wait.PollInfinite(time.Millisecond, func() (done bool, err error) { return manager.IsShutdown(), nil })
 		}()
+
+		ctxWithTimeout, timeoutCancel := context.WithTimeout(ctx, time.Second)
+		defer timeoutCancel()
+		if !cache.WaitForCacheSync(ctxWithTimeout.Done(), manager.HasSynced) {
+			g.Fail("Timed out waiting for InformerManager cache sync")
+		}
 
 		// 2. Verify that handler is not registered initially.
 
@@ -528,6 +602,7 @@ func TestInformerManager(t *testing.T) {
 		defaultFTCs := []*fedcorev1a1.FederatedTypeConfig{ftc}
 		defaultObjs := []*unstructured.Unstructured{dp1}
 		generators := []*EventHandlerGenerator{generator}
+		handlers := []FTCUpdateHandler{}
 
 		ctx, cancel := context.WithCancel(ctx)
 		manager, dynamicClient, fedClient := bootstrapInformerManagerWithFakeClients(
@@ -536,11 +611,18 @@ func TestInformerManager(t *testing.T) {
 			defaultFTCs,
 			defaultObjs,
 			generators,
+			handlers,
 		)
 		defer func() {
 			cancel()
 			_ = wait.PollInfinite(time.Millisecond, func() (done bool, err error) { return manager.IsShutdown(), nil })
 		}()
+
+		ctxWithTimeout, timeoutCancel := context.WithTimeout(ctx, time.Second)
+		defer timeoutCancel()
+		if !cache.WaitForCacheSync(ctxWithTimeout.Done(), manager.HasSynced) {
+			g.Fail("Timed out waiting for InformerManager cache sync")
+		}
 
 		// 2. Verify that handler is registered initially.
 
@@ -586,6 +668,7 @@ func TestInformerManager(t *testing.T) {
 		defaultFTCs := []*fedcorev1a1.FederatedTypeConfig{ftc}
 		defaultObjs := []*unstructured.Unstructured{dp1}
 		generators := []*EventHandlerGenerator{generator}
+		handlers := []FTCUpdateHandler{}
 
 		ctx, cancel := context.WithCancel(ctx)
 		manager, dynamicClient, fedClient := bootstrapInformerManagerWithFakeClients(
@@ -594,6 +677,7 @@ func TestInformerManager(t *testing.T) {
 			defaultFTCs,
 			defaultObjs,
 			generators,
+			handlers,
 		)
 		defer func() {
 			cancel()
@@ -645,6 +729,7 @@ func TestInformerManager(t *testing.T) {
 		defaultFTCs := []*fedcorev1a1.FederatedTypeConfig{ftc}
 		defaultObjs := []*unstructured.Unstructured{dp1}
 		generators := []*EventHandlerGenerator{generator}
+		handlers := []FTCUpdateHandler{}
 
 		ctx, cancel := context.WithCancel(ctx)
 		manager, dynamicClient, fedClient := bootstrapInformerManagerWithFakeClients(
@@ -653,11 +738,18 @@ func TestInformerManager(t *testing.T) {
 			defaultFTCs,
 			defaultObjs,
 			generators,
+			handlers,
 		)
 		defer func() {
 			cancel()
 			_ = wait.PollInfinite(time.Millisecond, func() (done bool, err error) { return manager.IsShutdown(), nil })
 		}()
+
+		ctxWithTimeout, timeoutCancel := context.WithTimeout(ctx, time.Second)
+		defer timeoutCancel()
+		if !cache.WaitForCacheSync(ctxWithTimeout.Done(), manager.HasSynced) {
+			g.Fail("Timed out waiting for InformerManager cache sync")
+		}
 
 		// 2. Verify that handler is registered initially
 
@@ -710,6 +802,7 @@ func TestInformerManager(t *testing.T) {
 		defaultFTCs := []*fedcorev1a1.FederatedTypeConfig{deploymentFTC, configmapFTC, secretFTC}
 		defaultObjs := []*unstructured.Unstructured{dp1, cm1, sc1}
 		generators := []*EventHandlerGenerator{generator1, generator2}
+		handlers := []FTCUpdateHandler{}
 
 		ctx, cancel := context.WithCancel(ctx)
 		manager, dynamicClient, fedClient := bootstrapInformerManagerWithFakeClients(
@@ -718,11 +811,18 @@ func TestInformerManager(t *testing.T) {
 			defaultFTCs,
 			defaultObjs,
 			generators,
+			handlers,
 		)
 		defer func() {
 			cancel()
 			_ = wait.PollInfinite(time.Millisecond, func() (done bool, err error) { return manager.IsShutdown(), nil })
 		}()
+
+		ctxWithTimeout, timeoutCancel := context.WithTimeout(ctx, time.Second)
+		defer timeoutCancel()
+		if !cache.WaitForCacheSync(ctxWithTimeout.Done(), manager.HasSynced) {
+			g.Fail("Timed out waiting for InformerManager cache sync")
+		}
 
 		// 2. Verify that handler1 and handler2 is registered initially for all FTCs
 
@@ -809,6 +909,7 @@ func TestInformerManager(t *testing.T) {
 		defaultFTCs := []*fedcorev1a1.FederatedTypeConfig{deploymentFTC, configmapFTC, secretFTC}
 		defaultObjs := []*unstructured.Unstructured{dp1, cm1, sc1}
 		generators := []*EventHandlerGenerator{generator1, generator2}
+		handlers := []FTCUpdateHandler{}
 
 		managerCtx, managerCancel := context.WithCancel(ctx)
 
@@ -819,11 +920,18 @@ func TestInformerManager(t *testing.T) {
 			defaultFTCs,
 			defaultObjs,
 			generators,
+			handlers,
 		)
 		defer func() {
 			cancel()
 			_ = wait.PollInfinite(time.Millisecond, func() (done bool, err error) { return manager.IsShutdown(), nil })
 		}()
+
+		ctxWithTimeout, timeoutCancel := context.WithTimeout(ctx, time.Second)
+		defer timeoutCancel()
+		if !cache.WaitForCacheSync(ctxWithTimeout.Done(), manager.HasSynced) {
+			g.Fail("Timed out waiting for InformerManager cache sync")
+		}
 
 		// 2. Verify that handler1 and handler2 is registered initially for all FTCs
 
@@ -872,6 +980,75 @@ func TestInformerManager(t *testing.T) {
 		handler1.AssertConsistently(g, time.Second*2)
 		handler2.AssertConsistently(g, time.Second*2)
 	})
+
+	t.Run("ftc update event handlers should be called on ftc events", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+
+		// 1. Bootstrap environment
+
+		generation := &atomic.Int64{}
+		generation.Store(1)
+
+		// assertionCh is used to achieve 3 things:
+		// 1. It is used to pass assertions to the main goroutine.
+		// 2. It is used as an implicit lock to ensure FTC events are not squashed by the InformerManager.
+		// 3. It is used to ensure that the last event has been processed before the main goroutine sends an update.
+		assertionCh := make(chan func())
+
+		ftc := deploymentFTC.DeepCopy()
+		ftc.SetGeneration(generation.Load())
+
+		handler := func(lastObserved, latest *fedcorev1a1.FederatedTypeConfig) {
+			curGeneration := generation.Load()
+			if curGeneration == 1 {
+				assertionCh <- func() {
+					g.Expect(lastObserved).To(gomega.BeNil())
+					g.Expect(latest.GetGeneration()).To(gomega.BeNumerically("==", 1))
+				}
+			} else {
+				assertionCh <- func() {
+					g.Expect(lastObserved.GetGeneration()).To(gomega.BeNumerically("==", curGeneration-1))
+					g.Expect(latest.GetGeneration()).To(gomega.BeNumerically("==", curGeneration))
+				}
+			}
+		}
+
+		defaultFTCs := []*fedcorev1a1.FederatedTypeConfig{ftc}
+		defaultObjs := []*unstructured.Unstructured{}
+		generators := []*EventHandlerGenerator{}
+		handlers := []FTCUpdateHandler{handler}
+
+		ctx, cancel := context.WithCancel(ctx)
+		manager, _, fedClient := bootstrapInformerManagerWithFakeClients(
+			g,
+			ctx,
+			defaultFTCs,
+			defaultObjs,
+			generators,
+			handlers,
+		)
+		defer func() {
+			cancel()
+			_ = wait.PollInfinite(time.Millisecond, func() (done bool, err error) { return manager.IsShutdown(), nil })
+		}()
+
+		fn := <-assertionCh
+		fn()
+
+		// 3. Generate FTC update events
+
+		for i := 0; i < 5; i++ {
+			generation.Add(1)
+			ftc.SetGeneration(generation.Load())
+
+			var err error
+			ftc, err = fedClient.CoreV1alpha1().FederatedTypeConfigs().Update(ctx, ftc, metav1.UpdateOptions{})
+			g.Expect(err).ToNot(gomega.HaveOccurred())
+
+			fn = <-assertionCh
+			fn()
+		}
+	})
 }
 
 func bootstrapInformerManagerWithFakeClients(
@@ -880,6 +1057,7 @@ func bootstrapInformerManagerWithFakeClients(
 	ftcs []*fedcorev1a1.FederatedTypeConfig,
 	objects []*unstructured.Unstructured,
 	eventHandlerGenerators []*EventHandlerGenerator,
+	ftcUpdateHandlers []FTCUpdateHandler,
 ) (InformerManager, dynamicclient.Interface, fedclient.Interface) {
 	scheme := runtime.NewScheme()
 
@@ -910,15 +1088,13 @@ func bootstrapInformerManagerWithFakeClients(
 		g.Expect(err).ToNot(gomega.HaveOccurred())
 	}
 
+	for _, handler := range ftcUpdateHandlers {
+		err := informerManager.AddFTCUpdateHandler(handler)
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+	}
+
 	factory.Start(ctx.Done())
 	informerManager.Start(ctx)
-
-	ctxWithTimeout, cancel := context.WithTimeout(ctx, time.Second)
-	defer cancel()
-
-	if !cache.WaitForCacheSync(ctxWithTimeout.Done(), informerManager.HasSynced) {
-		g.Fail("Timed out waiting for InformerManager cache sync")
-	}
 
 	return informerManager, dynamicClient, fedClient
 }

--- a/pkg/util/informermanager/interface.go
+++ b/pkg/util/informermanager/interface.go
@@ -39,6 +39,11 @@ type EventHandlerGenerator struct {
 	Generator func(ftc *fedcorev1a1.FederatedTypeConfig) cache.ResourceEventHandler
 }
 
+// FTCUpdateHandler is called by InformerManager each time it finishes processing an FTC. This allows controllers to
+// hook into the InformerManager's view of an FTC's lifecycle. When a new FTC is observed, lastObserved will be nil.
+// When a FTC deletion is observed, latest will be nil.
+type FTCUpdateHandler func(lastObserved, latest *fedcorev1a1.FederatedTypeConfig)
+
 // InformerManager provides an interface for controllers that need to dynamically register event handlers and access
 // objects based on FederatedTypeConfigs. InformerManager will listen to FTC events and maintain informers for the
 // source type of each FTC.
@@ -48,6 +53,9 @@ type EventHandlerGenerator struct {
 type InformerManager interface {
 	// Adds an EventHandler used to generate and register ResourceEventHandlers for each FTC's source type informer.
 	AddEventHandlerGenerator(generator *EventHandlerGenerator) error
+	// Adds a FTCUpdateHandler that is called each time the InformerManager finishes processing an FTC.
+	AddFTCUpdateHandler(handler FTCUpdateHandler) error
+
 	// Returns a lister for the given GroupResourceVersion if it exists. The lister for each FTC's source type will
 	// eventually exist.
 	GetResourceLister(gvk schema.GroupVersionKind) (lister cache.GenericLister, informerSynced cache.InformerSynced, exists bool)


### PR DESCRIPTION
This PR adds FTC update handlers that are called every time the `InformerManager` processes an FTC. The purpose of this is to allow controllers to hook into the `InformerManager`'s view of a FTC's lifecycle. For example, reenqueue all FOs and CFOs for a FTC when it is created or when its configuration changes.

In addition, `InformerManager.HasSynced` is also modified to only return `true` when an initial snapshot of FTCs is processed. This allows controllers to avoid false "lister not found" or "ftc not found" on controller-manager startup where it processes FOs or CFOs before their corresponding FTCs are processed by `InformerManager`.