### PR TITLE
feat: integrate pod informer to federated informer manager

### DIFF
--- a/cmd/controller-manager/app/util.go
+++ b/cmd/controller-manager/app/util.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/kubewharf/kubeadmiral/cmd/controller-manager/app/options"
@@ -115,19 +116,15 @@ func createControllerContext(opts *options.Options) (*controllercontext.Context,
 		nil,
 	)
 	federatedInformerManager := informermanager.NewFederatedInformerManager(
-		informermanager.ClusterClientGetter{
+		informermanager.ClusterClientHelper{
 			ConnectionHash: informermanager.DefaultClusterConnectionHash,
-			ClientGetter: func(cluster *fedcorev1a1.FederatedCluster) (dynamic.Interface, error) {
-				restConfig, err := clusterutil.BuildClusterConfig(
+			RestConfigGetter: func(cluster *fedcorev1a1.FederatedCluster) (*rest.Config, error) {
+				return clusterutil.BuildClusterConfig(
 					cluster,
 					kubeClientset,
 					restConfig,
 					common.DefaultFedSystemNamespace,
 				)
-				if err != nil {
-					return nil, err
-				}
-				return dynamic.NewForConfig(restConfig)
 			},
 		},
 		fedInformerFactory.Core().V1alpha1().FederatedTypeConfigs(),

--- a/pkg/util/informermanager/federatedinformermanager.go
+++ b/pkg/util/informermanager/federatedinformermanager.go
@@ -22,15 +22,22 @@ import (
 	"encoding/gob"
 	"fmt"
 	"sync"
+	"time"
 
+	"golang.org/x/sync/semaphore"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	v1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
@@ -50,40 +57,51 @@ type federatedInformerManager struct {
 	started  bool
 	shutdown bool
 
-	clientGetter    ClusterClientGetter
+	clientHelper        ClusterClientHelper
+	kubeClientGetter    func(*fedcorev1a1.FederatedCluster, *rest.Config) (kubernetes.Interface, error)
+	dynamicClientGetter func(*fedcorev1a1.FederatedCluster, *rest.Config) (dynamic.Interface, error)
+
 	ftcInformer     fedcorev1a1informers.FederatedTypeConfigInformer
 	clusterInformer fedcorev1a1informers.FederatedClusterInformer
 
 	eventHandlerGenerators []*EventHandlerGenerator
 	clusterEventHandlers   []*ClusterEventHandler
 
-	clients                     map[string]dynamic.Interface
-	connectionMap               map[string][]byte
-	informerManagers            map[string]InformerManager
-	informerManagersCancelFuncs map[string]context.CancelFunc
+	kubeClients        map[string]kubernetes.Interface
+	dynamicClients     map[string]dynamic.Interface
+	connectionMap      map[string][]byte
+	clusterCancelFuncs map[string]context.CancelFunc
+	informerManagers   map[string]InformerManager
+	informerFactories  map[string]informers.SharedInformerFactory
 
-	queue workqueue.RateLimitingInterface
+	queue              workqueue.RateLimitingInterface
+	podListerSemaphore *semaphore.Weighted
+	initialClusters    sets.Set[string]
 }
 
 func NewFederatedInformerManager(
-	clientGetter ClusterClientGetter,
+	clientHelper ClusterClientHelper,
 	ftcInformer fedcorev1a1informers.FederatedTypeConfigInformer,
 	clusterInformer fedcorev1a1informers.FederatedClusterInformer,
 ) FederatedInformerManager {
 	manager := &federatedInformerManager{
-		lock:                        sync.RWMutex{},
-		started:                     false,
-		shutdown:                    false,
-		clientGetter:                clientGetter,
-		ftcInformer:                 ftcInformer,
-		clusterInformer:             clusterInformer,
-		eventHandlerGenerators:      []*EventHandlerGenerator{},
-		clusterEventHandlers:        []*ClusterEventHandler{},
-		clients:                     map[string]dynamic.Interface{},
-		connectionMap:               map[string][]byte{},
-		informerManagers:            map[string]InformerManager{},
-		informerManagersCancelFuncs: map[string]context.CancelFunc{},
-		queue:                       workqueue.NewRateLimitingQueue(workqueue.DefaultItemBasedRateLimiter()),
+		lock:                   sync.RWMutex{},
+		started:                false,
+		shutdown:               false,
+		clientHelper:           clientHelper,
+		ftcInformer:            ftcInformer,
+		clusterInformer:        clusterInformer,
+		eventHandlerGenerators: []*EventHandlerGenerator{},
+		clusterEventHandlers:   []*ClusterEventHandler{},
+		kubeClients:            map[string]kubernetes.Interface{},
+		dynamicClients:         map[string]dynamic.Interface{},
+		connectionMap:          map[string][]byte{},
+		clusterCancelFuncs:     map[string]context.CancelFunc{},
+		informerManagers:       map[string]InformerManager{},
+		informerFactories:      map[string]informers.SharedInformerFactory{},
+		queue:                  workqueue.NewRateLimitingQueue(workqueue.DefaultItemBasedRateLimiter()),
+		podListerSemaphore:     semaphore.NewWeighted(3), // TODO: make this configurable
+		initialClusters:        sets.New[string](),
 	}
 
 	clusterInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
@@ -99,6 +117,13 @@ func NewFederatedInformerManager(
 	})
 
 	ftcInformer.Informer()
+
+	manager.dynamicClientGetter = func(_ *fedcorev1a1.FederatedCluster, config *rest.Config) (dynamic.Interface, error) {
+		return dynamic.NewForConfig(config)
+	}
+	manager.kubeClientGetter = func(_ *fedcorev1a1.FederatedCluster, config *rest.Config) (kubernetes.Interface, error) {
+		return kubernetes.NewForConfig(config)
+	}
 
 	return manager
 }
@@ -145,7 +170,7 @@ func (m *federatedInformerManager) worker(ctx context.Context) {
 		return
 	}
 
-	err, needReenqueue := m.processCluster(ctx, cluster)
+	err, needReenqueue, delay := m.processCluster(ctx, cluster)
 	if err != nil {
 		if needReenqueue {
 			logger.Error(err, "Failed to process FederatedCluster, will retry")
@@ -159,22 +184,22 @@ func (m *federatedInformerManager) worker(ctx context.Context) {
 
 	m.queue.Forget(key)
 	if needReenqueue {
-		m.queue.Add(key)
+		m.queue.AddAfter(key, delay)
 	}
 }
 
 func (m *federatedInformerManager) processCluster(
 	ctx context.Context,
 	cluster *fedcorev1a1.FederatedCluster,
-) (err error, needReenqueue bool) {
+) (err error, needReenqueue bool, delay time.Duration) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
 	clusterName := cluster.Name
 
-	connectionHash, err := m.clientGetter.ConnectionHash(cluster)
+	connectionHash, err := m.clientHelper.ConnectionHash(cluster)
 	if err != nil {
-		return fmt.Errorf("failed to get connection hash for cluster %s: %w", clusterName, err), true
+		return fmt.Errorf("failed to get connection hash for cluster %s: %w", clusterName, err), true, 0
 	}
 	if oldConnectionHash, exists := m.connectionMap[clusterName]; exists {
 		if !bytes.Equal(oldConnectionHash, connectionHash) {
@@ -183,16 +208,26 @@ func (m *federatedInformerManager) processCluster(
 			// reenqueue.
 			// Note: updating of cluster connection details, however, is still not a supported use case.
 			err := m.processClusterDeletionUnlocked(ctx, clusterName)
-			return err, true
+			return err, true, 0
 		}
 	} else {
-		clusterClient, err := m.clientGetter.ClientGetter(cluster)
+		clusterRestConfig, err := m.clientHelper.RestConfigGetter(cluster)
 		if err != nil {
-			return fmt.Errorf("failed to get client for cluster %s: %w", clusterName, err), true
+			return fmt.Errorf("failed to get rest config for cluster %s: %w", clusterName, err), true, 0
+		}
+
+		clusterDynamicClient, err := m.dynamicClientGetter(cluster, clusterRestConfig)
+		if err != nil {
+			return fmt.Errorf("failed to get dynamic client for cluster %s: %w", clusterName, err), true, 0
+		}
+
+		clusterKubeClient, err := m.kubeClientGetter(cluster, clusterRestConfig)
+		if err != nil {
+			return fmt.Errorf("failed to get kubernetes client for cluster %s: %w", clusterName, err), true, 0
 		}
 
 		manager := NewInformerManager(
-			clusterClient,
+			clusterDynamicClient,
 			m.ftcInformer,
 			func(opts *metav1.ListOptions) {
 				selector := &metav1.LabelSelector{}
@@ -209,21 +244,39 @@ func (m *federatedInformerManager) processCluster(
 		for _, generator := range m.eventHandlerGenerators {
 			if err := manager.AddEventHandlerGenerator(generator); err != nil {
 				cancel()
-				return fmt.Errorf("failed to initialized InformerManager for cluster %s: %w", clusterName, err), true
+				return fmt.Errorf("failed to initialized InformerManager for cluster %s: %w", clusterName, err), true, 0
 			}
 		}
 
-		klog.FromContext(ctx).V(2).Info("Starting new InformerManager for FederatedCluster")
+		factory := informers.NewSharedInformerFactory(clusterKubeClient, 0)
+		addPodInformer(ctx, factory, clusterKubeClient, m.podListerSemaphore, true)
+		factory.Core().V1().Nodes().Informer()
 
+		klog.FromContext(ctx).V(2).Info("Starting new InformerManager for FederatedCluster")
 		manager.Start(ctx)
 
+		klog.FromContext(ctx).V(2).Info("Starting new SharedInformerFactory for FederatedCluster")
+		factory.Start(ctx.Done())
+
 		m.connectionMap[clusterName] = connectionHash
-		m.clients[clusterName] = clusterClient
+		m.kubeClients[clusterName] = clusterKubeClient
+		m.dynamicClients[clusterName] = clusterDynamicClient
+		m.clusterCancelFuncs[clusterName] = cancel
 		m.informerManagers[clusterName] = manager
-		m.informerManagersCancelFuncs[clusterName] = cancel
+		m.informerFactories[clusterName] = factory
 	}
 
-	return nil, false
+	if m.initialClusters.Has(cluster.Name) {
+		manager := m.informerManagers[cluster.Name]
+		if manager != nil && manager.HasSynced() {
+			m.initialClusters.Delete(cluster.Name)
+		} else {
+			klog.FromContext(ctx).V(3).Info("Waiting for InformerManager sync")
+			return nil, true, 100 * time.Millisecond
+		}
+	}
+
+	return nil, false, 0
 }
 
 func (m *federatedInformerManager) processClusterDeletion(ctx context.Context, clusterName string) error {
@@ -234,14 +287,16 @@ func (m *federatedInformerManager) processClusterDeletion(ctx context.Context, c
 
 func (m *federatedInformerManager) processClusterDeletionUnlocked(ctx context.Context, clusterName string) error {
 	delete(m.connectionMap, clusterName)
-	delete(m.clients, clusterName)
+	delete(m.dynamicClients, clusterName)
 
-	if cancel, ok := m.informerManagersCancelFuncs[clusterName]; ok {
+	if cancel, ok := m.clusterCancelFuncs[clusterName]; ok {
 		klog.FromContext(ctx).V(2).Info("Stopping InformerManager for FederatedCluster")
 		cancel()
 	}
 	delete(m.informerManagers, clusterName)
-	delete(m.informerManagersCancelFuncs, clusterName)
+	delete(m.clusterCancelFuncs, clusterName)
+
+	m.initialClusters.Delete(clusterName)
 
 	return nil
 }
@@ -270,10 +325,17 @@ func (m *federatedInformerManager) AddEventHandlerGenerator(generator *EventHand
 	return nil
 }
 
-func (m *federatedInformerManager) GetClusterClient(cluster string) (client dynamic.Interface, exists bool) {
+func (m *federatedInformerManager) GetClusterDynamicClient(cluster string) (client dynamic.Interface, exists bool) {
 	m.lock.RLock()
 	defer m.lock.RUnlock()
-	client, ok := m.clients[cluster]
+	client, ok := m.dynamicClients[cluster]
+	return client, ok
+}
+
+func (m *federatedInformerManager) GetClusterKubeClient(cluster string) (client kubernetes.Interface, exists bool) {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+	client, ok := m.kubeClients[cluster]
 	return client, ok
 }
 
@@ -301,6 +363,34 @@ func (m *federatedInformerManager) GetFederatedTypeConfigLister() fedcorev1a1lis
 	return m.ftcInformer.Lister()
 }
 
+func (m *federatedInformerManager) GetNodeLister(
+	cluster string,
+) (lister v1.NodeLister, informerSynced cache.InformerSynced, exists bool) {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+
+	factory, ok := m.informerFactories[cluster]
+	if !ok {
+		return nil, nil, false
+	}
+
+	return factory.Core().V1().Nodes().Lister(), factory.Core().V1().Nodes().Informer().HasSynced, true
+}
+
+func (m *federatedInformerManager) GetPodLister(
+	cluster string,
+) (lister v1.PodLister, informerSynced cache.InformerSynced, exists bool) {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+
+	factory, ok := m.informerFactories[cluster]
+	if !ok {
+		return nil, nil, false
+	}
+
+	return factory.Core().V1().Pods().Lister(), factory.Core().V1().Pods().Informer().HasSynced, true
+}
+
 func (m *federatedInformerManager) GetResourceLister(
 	gvk schema.GroupVersionKind,
 	cluster string,
@@ -317,7 +407,10 @@ func (m *federatedInformerManager) GetResourceLister(
 }
 
 func (m *federatedInformerManager) HasSynced() bool {
-	return m.ftcInformer.Informer().HasSynced() && m.clusterInformer.Informer().HasSynced()
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+	return m.ftcInformer.Informer().HasSynced() && m.clusterInformer.Informer().HasSynced() &&
+		len(m.initialClusters) == 0
 }
 
 func (m *federatedInformerManager) Start(ctx context.Context) {
@@ -333,9 +426,16 @@ func (m *federatedInformerManager) Start(ctx context.Context) {
 
 	m.started = true
 
-	if !cache.WaitForCacheSync(ctx.Done(), m.HasSynced) {
+	if !cache.WaitForCacheSync(ctx.Done(), m.ftcInformer.Informer().HasSynced, m.clusterInformer.Informer().HasSynced) {
 		logger.Error(nil, "Failed to wait for FederatedInformerManager cache sync")
 		return
+	}
+
+	// Populate the initial snapshot of clusters
+
+	clusters := m.clusterInformer.Informer().GetStore().List()
+	for _, cluster := range clusters {
+		m.initialClusters.Insert(cluster.(*fedcorev1a1.FederatedCluster).GetName())
 	}
 
 	for _, handler := range m.clusterEventHandlers {
@@ -428,7 +528,7 @@ func GetClusterObject(
 		return clusterObj.(*unstructured.Unstructured), true, nil
 	}
 
-	client, exists := fedInformerManager.GetClusterClient(clusterName)
+	client, exists := fedInformerManager.GetClusterDynamicClient(clusterName)
 	if !exists {
 		return nil, false, fmt.Errorf("cluster client does not exist for cluster %q", clusterName)
 	}

--- a/pkg/util/informermanager/podinformer.go
+++ b/pkg/util/informermanager/podinformer.go
@@ -36,15 +36,17 @@ func addPodInformer(ctx context.Context,
 	podListerSemaphore *semaphore.Weighted,
 	enablePodPruning bool,
 ) {
-	informer.InformerFor(&corev1.Pod{}, func(k kubeclient.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-		return cache.NewSharedIndexInformer(
-			podListerWatcher(ctx, client, podListerSemaphore, enablePodPruning),
-			&corev1.Pod{},
-			resyncPeriod,
-			cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
-		)
-	})
-
+	informer.InformerFor(
+		&corev1.Pod{},
+		func(k kubeclient.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+			return cache.NewSharedIndexInformer(
+				podListerWatcher(ctx, client, podListerSemaphore, enablePodPruning),
+				&corev1.Pod{},
+				resyncPeriod,
+				cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+			)
+		},
+	)
 }
 
 func podListerWatcher(

--- a/pkg/util/informermanager/podinformer.go
+++ b/pkg/util/informermanager/podinformer.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2023 The KubeAdmiral Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package informermanager
+
+import (
+	"context"
+	"time"
+
+	"golang.org/x/sync/semaphore"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/informers"
+	kubeclient "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+func addPodInformer(ctx context.Context,
+	informer informers.SharedInformerFactory,
+	client kubeclient.Interface,
+	podListerSemaphore *semaphore.Weighted,
+	enablePodPruning bool,
+) {
+	informer.InformerFor(&corev1.Pod{}, func(k kubeclient.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+		return cache.NewSharedIndexInformer(
+			podListerWatcher(ctx, client, podListerSemaphore, enablePodPruning),
+			&corev1.Pod{},
+			resyncPeriod,
+			cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		)
+	})
+
+}
+
+func podListerWatcher(
+	ctx context.Context,
+	client kubeclient.Interface,
+	semaphore *semaphore.Weighted,
+	enablePodPruning bool,
+) cache.ListerWatcher {
+	return &cache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			if semaphore != nil {
+				if err := semaphore.Acquire(ctx, 1); err != nil {
+					return nil, err
+				}
+				defer semaphore.Release(1)
+			}
+			pods, err := client.CoreV1().Pods(corev1.NamespaceAll).List(ctx, options)
+			if err != nil {
+				return nil, err
+			}
+			if enablePodPruning {
+				for i := range pods.Items {
+					prunePod(&pods.Items[i])
+				}
+			}
+			return pods, nil
+		},
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			watcher, err := client.CoreV1().Pods(corev1.NamespaceAll).Watch(ctx, options)
+			if err != nil {
+				return nil, err
+			}
+			if !enablePodPruning {
+				return watcher, nil
+			}
+
+			// It's easy for a consumer to add buffering via an extra
+			// goroutine/channel, but impossible for them to remove it,
+			// so nonbuffered is better. -- from watch.NewStreamWatcher
+			proxyCh := make(chan watch.Event)
+			proxyWatcher := watch.NewProxyWatcher(proxyCh)
+			go func() {
+				defer watcher.Stop()
+				// Closing proxyCh will notify the reflector to stop the current
+				// watching cycle and then restart the list and watch.
+				defer close(proxyCh)
+				for {
+					select {
+					case <-proxyWatcher.StopChan():
+						return
+					case event, ok := <-watcher.ResultChan():
+						if !ok {
+							// the watcher has been closed, stop the proxy
+							return
+						}
+						if pod, ok := event.Object.(*corev1.Pod); ok {
+							prunePod(pod)
+						}
+						proxyCh <- event
+					}
+				}
+			}()
+			return proxyWatcher, nil
+		},
+	}
+}
+
+func prunePod(pod *corev1.Pod) {
+	containers := make([]corev1.Container, len(pod.Spec.Containers))
+	initContainers := make([]corev1.Container, len(pod.Spec.InitContainers))
+	for i := range pod.Spec.Containers {
+		containers[i] = corev1.Container{Resources: pod.Spec.Containers[i].Resources}
+	}
+	for i := range pod.Spec.InitContainers {
+		initContainers[i] = corev1.Container{Resources: pod.Spec.InitContainers[i].Resources}
+	}
+	*pod = corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            pod.Name,
+			Namespace:       pod.Namespace,
+			Generation:      pod.Generation,
+			ResourceVersion: pod.ResourceVersion,
+			UID:             pod.UID,
+		},
+		Spec: corev1.PodSpec{
+			NodeName:       pod.Spec.NodeName,
+			Overhead:       pod.Spec.Overhead,
+			Containers:     containers,
+			InitContainers: initContainers,
+		},
+	}
+}


### PR DESCRIPTION
This PR integartes the old custom pod informer in `FederatedClient` into `FederatedInformerManager`. This is in preparation for the FederatedCluster controller refactor. 

Additionally, `FederatedInformerManager` now also waits for an initial snapshot of clusters to be reconciled and their respective `InformerManagers` to be synced before returning true in its own `HasSynced` method. This reduces the amount of false errors on start-up where host `InformerManager`'s view of FTCs is out of sync with the member `InformerManagers`' view.