### PR TITLE
chore:add log when federated cluster is not ready

### DIFF
--- a/pkg/controllers/federatedcluster/controller.go
+++ b/pkg/controllers/federatedcluster/controller.go
@@ -320,7 +320,7 @@ func (c *FederatedClusterController) collectClusterStatus(qualifiedName common.Q
 
 	cluster = cluster.DeepCopy()
 	if shouldCollectClusterStatus(cluster, c.clusterHealthCheckConfig.Period) {
-		if err := collectIndividualClusterStatus(ctx, cluster, c.client, c.federatedClient); err != nil {
+		if err := c.collectIndividualClusterStatus(ctx, cluster, c.client, c.federatedClient); err != nil {
 			logger.Error(err, "Failed to collect cluster status")
 			return worker.StatusError
 		}


### PR DESCRIPTION
Record the cluster health check body when federated cluster is not ready, so we can analyze the cause of the anomaly.