### PR TITLE
fix: kubeadmiral-controller-manager crash when make local-up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ build:
 #
 # It will directly start the kubeadmiral control-plane cluster(excluding the kubeadmiral-controller-manager) and three member-clusters.
 # Users can run the kubeadmiral-controller-manager component through binary for easy debugging, e.g.:
-# ./output/bin/darwin/amd64/kubeadmiral-controller-manager_debug --create-crds-for-ftcs \
+# ./output/bin/darwin/amd64/kubeadmiral-controller-manager_debug \
 #    --klog-logtostderr=false \
 #    --klog-log-file "./kubeadmiral.log" \
 #    --kubeconfig "$HOME/.kube/kubeadmiral/kubeadmiral-host.yaml" \

--- a/config/deploy/controlplane/kubeadmiral-controller-manager.yaml
+++ b/config/deploy/controlplane/kubeadmiral-controller-manager.yaml
@@ -19,7 +19,6 @@ spec:
         - name: kubeadmiral-controller-manager
           command:
             - /kubeadmiral-controller-manager
-            - --create-crds-for-ftcs=true
             - --kubeconfig=/etc/kubeconfig
             - --klog-v=4
           livenessProbe:


### PR DESCRIPTION
Since kubeadmiral-controller-manager no longer needs to the flag `--create-crds-for-ftcs`, we need to delete the flag in the deploy yaml.