### PR TITLE
Support gpu scheduling

### DIFF
--- a/pkg/controllers/scheduler/framework/plugins/clusterresources/least_allocated_test.go
+++ b/pkg/controllers/scheduler/framework/plugins/clusterresources/least_allocated_test.go
@@ -24,9 +24,22 @@ import (
 	"context"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/api/resource"
+
 	fedcorev1a1 "github.com/kubewharf/kubeadmiral/pkg/apis/core/v1alpha1"
 	"github.com/kubewharf/kubeadmiral/pkg/controllers/scheduler/framework"
 )
+
+func schedulingUnitWithGPU(su *framework.SchedulingUnit, value int64) *framework.SchedulingUnit {
+	su.ResourceRequest.SetScalar(framework.ResourceGPU, value)
+	return su
+}
+
+func clusterWithGPU(fc *fedcorev1a1.FederatedCluster, allocatable, available int64) *fedcorev1a1.FederatedCluster {
+	fc.Status.Resources.Allocatable[framework.ResourceGPU] = *resource.NewQuantity(allocatable, resource.BinarySI)
+	fc.Status.Resources.Available[framework.ResourceGPU] = *resource.NewQuantity(available, resource.BinarySI)
+	return fc
+}
 
 func TestClusterResourcesLeastAllocated(t *testing.T) {
 	tests := []struct {
@@ -36,14 +49,14 @@ func TestClusterResourcesLeastAllocated(t *testing.T) {
 		expectedList framework.ClusterScoreList
 	}{
 		{
-			// Cluster1 scores (remaining resources) on 0-10 scale
+			// Cluster1 scores (remaining resources) on 0-100 scale
 			// CPU Fraction: 0 / 4000 = 0%
 			// Memory Fraction: 0 / 10000 = 0%
-			// Cluster1 Score: 10 - (0-0)*100 = 100
-			// Cluster2 scores (remaining resources) on 0-10 scale
+			// Cluster1 Score: 100 - (0-0)*100 = 100
+			// Cluster2 scores (remaining resources) on 0-100 scale
 			// CPU Fraction: 0 / 4000 = 0 %
 			// Memory Fraction: 0 / 10000 = 0%
-			// Cluster2 Score: 10 - (0-0)*100 = 100
+			// Cluster2 Score: 100 - (0-0)*100 = 100
 			su: makeSchedulingUnit("su1", 0, 0),
 			clusters: []*fedcorev1a1.FederatedCluster{
 				makeCluster("cluster1", 4000, 10000, 4000, 10000),
@@ -56,14 +69,14 @@ func TestClusterResourcesLeastAllocated(t *testing.T) {
 			name: "nothing scheduled, nothing requested",
 		},
 		{
-			// Cluster1 scores on 0-10 scale
+			// Cluster1 scores on 0-100 scale
 			// CPU Fraction: 3000 / 4000= 75%
 			// Memory Fraction: 5000 / 10000 = 50%
-			// Cluster1 Score: 10 - (0.75-0.5)*100 = 75
-			// Cluster2 scores on 0-10 scale
+			// Cluster1 Score: 100 - (0.75-0.5)*100 = 75
+			// Cluster2 scores on 0-100 scale
 			// CPU Fraction: 3000 / 6000= 50%
 			// Memory Fraction: 5000/10000 = 50%
-			// Cluster2 Score: 10 - (0.5-0.5)*100 = 100
+			// Cluster2 Score: 100 - (0.5-0.5)*100 = 100
 			su: makeSchedulingUnit("su2", 3000, 5000),
 			clusters: []*fedcorev1a1.FederatedCluster{
 				makeCluster("cluster1", 4000, 10000, 4000, 10000),
@@ -74,6 +87,28 @@ func TestClusterResourcesLeastAllocated(t *testing.T) {
 				{Cluster: makeCluster("cluster2", 6000, 10000, 6000, 10000), Score: 50},
 			},
 			name: "nothing scheduled, resources requested, differently sized machines",
+		},
+		{
+			// Cluster1 scores on 0-100 scale
+			// CPU Fraction: 3000 / 4000= 75%
+			// Memory Fraction: 5000 / 10000 = 50%
+			// GPU Fraction: 5000 / 10000 = 50%
+			// Cluster1 Score: (25 + 50 + 50 * 4) / 6 = 45
+			// Cluster2 scores on 0-100 scale
+			// CPU Fraction: 3000 / 6000= 50%
+			// Memory Fraction: 5000/10000 = 50%
+			// GPU Fraction: 5000/10000 = 50%
+			// Cluster2 Score: (50 + 50 + 50 * 4) / 6 = 50
+			su: schedulingUnitWithGPU(makeSchedulingUnit("su2", 3000, 5000), 5000),
+			clusters: []*fedcorev1a1.FederatedCluster{
+				clusterWithGPU(makeCluster("cluster1", 4000, 10000, 4000, 10000), 10000, 10000),
+				clusterWithGPU(makeCluster("cluster2", 6000, 10000, 6000, 10000), 10000, 10000),
+			},
+			expectedList: []framework.ClusterScore{
+				{Cluster: makeCluster("cluster1", 4000, 10000, 4000, 10000), Score: 45},
+				{Cluster: makeCluster("cluster2", 6000, 10000, 6000, 10000), Score: 50},
+			},
+			name: "nothing scheduled, resources requested with gpu, differently sized machines",
 		},
 	}
 

--- a/pkg/controllers/scheduler/framework/plugins/clusterresources/most_allocated_test.go
+++ b/pkg/controllers/scheduler/framework/plugins/clusterresources/most_allocated_test.go
@@ -36,14 +36,14 @@ func TestClusterResourcesMostAllocated(t *testing.T) {
 		expectedList framework.ClusterScoreList
 	}{
 		{
-			// Cluster1 scores (remaining resources) on 0-10 scale
+			// Cluster1 scores (remaining resources) on 0-100 scale
 			// CPU Fraction: 0 / 4000 = 0%
 			// Memory Fraction: 0 / 10000 = 0%
-			// Cluster1 Score: 10 - (0-0)*100 = 100
-			// Cluster2 scores (remaining resources) on 0-10 scale
+			// Cluster1 Score: 100 - (0-0)*100 = 100
+			// Cluster2 scores (remaining resources) on 0-100 scale
 			// CPU Fraction: 0 / 4000 = 0 %
 			// Memory Fraction: 0 / 10000 = 0%
-			// Cluster2 Score: 10 - (0-0)*100 = 100
+			// Cluster2 Score: 100 - (0-0)*100 = 100
 			su: makeSchedulingUnit("su1", 0, 0),
 			clusters: []*fedcorev1a1.FederatedCluster{
 				makeCluster("cluster1", 4000, 10000, 4000, 10000),
@@ -56,14 +56,14 @@ func TestClusterResourcesMostAllocated(t *testing.T) {
 			name: "nothing scheduled, nothing requested",
 		},
 		{
-			// Cluster1 scores on 0-10 scale
+			// Cluster1 scores on 0-100 scale
 			// CPU Fraction: 3000 / 4000= 75%
 			// Memory Fraction: 5000 / 10000 = 50%
-			// Cluster1 Score: 10 - (0.75-0.5)*100 = 75
-			// Cluster2 scores on 0-10 scale
+			// Cluster1 Score: 100 - (0.75-0.5)*100 = 75
+			// Cluster2 scores on 0-100 scale
 			// CPU Fraction: 3000 / 6000= 50%
 			// Memory Fraction: 5000/10000 = 50%
-			// Cluster2 Score: 10 - (0.5-0.5)*100 = 100
+			// Cluster2 Score: 100 - (0.5-0.5)*100 = 100
 			su: makeSchedulingUnit("su2", 3000, 5000),
 			clusters: []*fedcorev1a1.FederatedCluster{
 				makeCluster("cluster1", 4000, 10000, 4000, 10000),
@@ -74,6 +74,28 @@ func TestClusterResourcesMostAllocated(t *testing.T) {
 				{Cluster: makeCluster("cluster2", 6000, 10000, 6000, 10000), Score: 50},
 			},
 			name: "nothing scheduled, resources requested, differently sized machines",
+		},
+		{
+			// Cluster1 scores on 0-100 scale
+			// CPU Fraction: 3000 / 4000= 75%
+			// Memory Fraction: 5000 / 10000 = 50%
+			// GPU Fraction: 5000 / 10000 = 50%
+			// Cluster1 Score: (75 + 50 + 50 * 4) / 6 = 54
+			// Cluster2 scores on 0-100 scale
+			// CPU Fraction: 3000 / 6000= 50%
+			// Memory Fraction: 5000/10000 = 50%
+			// GPU Fraction: 5000/10000 = 50%
+			// Cluster2 Score: (50 + 50 + 50 * 4) / 6 = 50
+			su: schedulingUnitWithGPU(makeSchedulingUnit("su2", 3000, 5000), 5000),
+			clusters: []*fedcorev1a1.FederatedCluster{
+				clusterWithGPU(makeCluster("cluster1", 4000, 10000, 4000, 10000), 10000, 10000),
+				clusterWithGPU(makeCluster("cluster2", 6000, 10000, 6000, 10000), 10000, 10000),
+			},
+			expectedList: []framework.ClusterScore{
+				{Cluster: makeCluster("cluster1", 4000, 10000, 4000, 10000), Score: 54},
+				{Cluster: makeCluster("cluster2", 6000, 10000, 6000, 10000), Score: 50},
+			},
+			name: "nothing scheduled, resources requested with gpu, differently sized machines",
 		},
 	}
 

--- a/pkg/controllers/scheduler/framework/plugins/rsp/rsp_test.go
+++ b/pkg/controllers/scheduler/framework/plugins/rsp/rsp_test.go
@@ -152,7 +152,7 @@ func TestCalcWeightLimit(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotWeightLimit, err := CalcWeightLimit(tt.args.clusters, tt.args.supplyLimitRatio)
+			gotWeightLimit, err := CalcWeightLimit(tt.args.clusters, corev1.ResourceCPU, tt.args.supplyLimitRatio)
 			if !tt.wantErr(t, err, fmt.Sprintf("CalcWeightLimit(%v)", tt.args.clusters)) {
 				return
 			}
@@ -170,7 +170,7 @@ func TestAvailableToPercentage(t *testing.T) {
 		return args{
 			clusterAvailables: QueryAvailable(clusters),
 			weightLimit: func() map[string]int64 {
-				weightLimit, _ := CalcWeightLimit(clusters, 1.0)
+				weightLimit, _ := CalcWeightLimit(clusters, corev1.ResourceCPU, 1.0)
 				return weightLimit
 			}(),
 		}
@@ -247,7 +247,7 @@ func TestAvailableToPercentage(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotClusterWeights, err := AvailableToPercentage(tt.args.clusterAvailables, tt.args.weightLimit)
+			gotClusterWeights, err := AvailableToPercentage(tt.args.clusterAvailables, corev1.ResourceCPU, tt.args.weightLimit)
 			if !tt.wantErr(
 				t,
 				err,

--- a/pkg/controllers/scheduler/framework/util.go
+++ b/pkg/controllers/scheduler/framework/util.go
@@ -33,6 +33,10 @@ import (
 	fedcorev1a1 "github.com/kubewharf/kubeadmiral/pkg/apis/core/v1alpha1"
 )
 
+const (
+	ResourceGPU = corev1.ResourceName("nvidia.com/gpu")
+)
+
 // For each of these resources, a pod that doesn't request the resource explicitly
 // will be treated as having requested the amount indicated below, for the purpose
 // of computing priority only. This ensures that when scheduling zero-request pods, such
@@ -59,7 +63,10 @@ const (
 
 // TODO(feature), make the RequestedRatioResources configable
 
-var DefaultRequestedRatioResources = ResourceToWeightMap{corev1.ResourceMemory: 1, corev1.ResourceCPU: 1}
+var (
+	DefaultRequestedRatioResources        = ResourceToWeightMap{corev1.ResourceMemory: 1, corev1.ResourceCPU: 1}
+	DefaultRequestedRatioResourcesWithGPU = ResourceToWeightMap{corev1.ResourceMemory: 1, corev1.ResourceCPU: 1, ResourceGPU: 4}
+)
 
 type (
 	ResourceToValueMap  map[corev1.ResourceName]int64
@@ -243,6 +250,18 @@ func (r *Resource) SetMaxResource(rl corev1.ResourceList) {
 			}
 		}
 	}
+}
+
+// HasGivenResource checks if Resource has the given scalar resource.
+func (r *Resource) HasGivenResource(name corev1.ResourceName) bool {
+	if r.ScalarResources == nil {
+		return false
+	}
+
+	if _, exists := r.ScalarResources[name]; exists {
+		return true
+	}
+	return false
 }
 
 // resourceRequest = max(sum(podSpec.Containers), podSpec.InitContainers) + overHead


### PR DESCRIPTION
Pass the gpu resourceQuest into schedulingUnit so that we can filter and score the cluster based on gpu resource quest of workloads.
At present, the interpret of the PodTemplate path of K8s native resources is built in, and it can be put into FTC for subsequent consideration.

Refer to https://github.com/kubewharf/kubeadmiral/blob/7ede6f4b715d2b3861ce8a6b4f681cc229d86cfe/pkg/util/pod/pod.go#L38