### PR TITLE
feat: add cluster metrics

### DIFF
--- a/pkg/controllers/federatedcluster/controller.go
+++ b/pkg/controllers/federatedcluster/controller.go
@@ -220,6 +220,12 @@ func (c *FederatedClusterController) reconcile(
 	cluster = cluster.DeepCopy()
 
 	if cluster.GetDeletionTimestamp() != nil {
+		c.metrics.Store("cluster_deletion_state", 1,
+			stats.Tag{Name: "cluster_name", Value: cluster.Name},
+			stats.Tag{Name: "status", Value: "deleting"})
+		c.metrics.Store("cluster_deletion_state", 0,
+			stats.Tag{Name: "cluster_name", Value: cluster.Name},
+			stats.Tag{Name: "status", Value: "deleted"})
 		logger.V(2).Info("Handle terminating cluster")
 		if err := c.handleTerminatingCluster(ctx, cluster); err != nil {
 			if apierrors.IsConflict(err) {
@@ -446,6 +452,12 @@ func (c *FederatedClusterController) handleTerminatingCluster(
 		return fmt.Errorf("failed to update cluster for finalizer removal: %w", err)
 	}
 
+	c.metrics.Store("cluster_deletion_state", 0,
+		stats.Tag{Name: "cluster_name", Value: cluster.Name},
+		stats.Tag{Name: "status", Value: "deleting"})
+	c.metrics.Store("cluster_deletion_state", 1,
+		stats.Tag{Name: "cluster_name", Value: cluster.Name},
+		stats.Tag{Name: "status", Value: "deleted"})
 	return nil
 }
 

--- a/pkg/util/cluster/util.go
+++ b/pkg/util/cluster/util.go
@@ -43,3 +43,14 @@ func IsClusterJoined(clusterStatus *fedcorev1a1.FederatedClusterStatus) bool {
 	}
 	return false
 }
+
+func IsClusterOffline(clusterStatus *fedcorev1a1.FederatedClusterStatus) bool {
+	for _, condition := range clusterStatus.Conditions {
+		if condition.Type == fedcorev1a1.ClusterOffline {
+			if condition.Status == corev1.ConditionTrue {
+				return true
+			}
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Add cluster metrics.
Test results:
```
# HELP kubeadmiral_controller_manager_cluster_cpu_allocatable_number 
# TYPE kubeadmiral_controller_manager_cluster_cpu_allocatable_number gauge
kubeadmiral_controller_manager_cluster_cpu_allocatable_number{cluster_name="kubeadmiral-member-1"} 4
kubeadmiral_controller_manager_cluster_cpu_allocatable_number{cluster_name="kubeadmiral-member-2"} 4
kubeadmiral_controller_manager_cluster_cpu_allocatable_number{cluster_name="kubeadmiral-member-3"} 4
# HELP kubeadmiral_controller_manager_cluster_cpu_available_number 
# TYPE kubeadmiral_controller_manager_cluster_cpu_available_number gauge
kubeadmiral_controller_manager_cluster_cpu_available_number{cluster_name="kubeadmiral-member-1"} 3.0500000000000003
kubeadmiral_controller_manager_cluster_cpu_available_number{cluster_name="kubeadmiral-member-2"} 3.0500000000000003
kubeadmiral_controller_manager_cluster_cpu_available_number{cluster_name="kubeadmiral-member-3"} 3.0500000000000003
# HELP kubeadmiral_controller_manager_cluster_memory_allocatable_bytes 
# TYPE kubeadmiral_controller_manager_cluster_memory_allocatable_bytes gauge
kubeadmiral_controller_manager_cluster_memory_allocatable_bytes{cluster_name="kubeadmiral-member-1"} 8.241246208e+09
kubeadmiral_controller_manager_cluster_memory_allocatable_bytes{cluster_name="kubeadmiral-member-2"} 8.241246208e+09
kubeadmiral_controller_manager_cluster_memory_allocatable_bytes{cluster_name="kubeadmiral-member-3"} 8.241246208e+09
# HELP kubeadmiral_controller_manager_cluster_memory_available_bytes 
# TYPE kubeadmiral_controller_manager_cluster_memory_available_bytes gauge
kubeadmiral_controller_manager_cluster_memory_available_bytes{cluster_name="kubeadmiral-member-1"} 7.937159168e+09
kubeadmiral_controller_manager_cluster_memory_available_bytes{cluster_name="kubeadmiral-member-2"} 7.937159168e+09
kubeadmiral_controller_manager_cluster_memory_available_bytes{cluster_name="kubeadmiral-member-3"} 7.937159168e+09
# HELP kubeadmiral_controller_manager_cluster_offline_state 
# TYPE kubeadmiral_controller_manager_cluster_offline_state gauge
kubeadmiral_controller_manager_cluster_offline_state{cluster_name="kubeadmiral-member-1"} 0
kubeadmiral_controller_manager_cluster_offline_state{cluster_name="kubeadmiral-member-2"} 0
kubeadmiral_controller_manager_cluster_offline_state{cluster_name="kubeadmiral-member-3"} 0
# HELP kubeadmiral_controller_manager_cluster_ready_state 
# TYPE kubeadmiral_controller_manager_cluster_ready_state gauge
kubeadmiral_controller_manager_cluster_ready_state{cluster_name="kubeadmiral-member-1"} 1
kubeadmiral_controller_manager_cluster_ready_state{cluster_name="kubeadmiral-member-2"} 1
kubeadmiral_controller_manager_cluster_ready_state{cluster_name="kubeadmiral-member-3"} 1
# HELP kubeadmiral_controller_manager_cluster_joined_state 
# TYPE kubeadmiral_controller_manager_cluster_joined_state gauge
kubeadmiral_controller_manager_cluster_joined_state{cluster_name="kubeadmiral-member-1"} 1
kubeadmiral_controller_manager_cluster_joined_state{cluster_name="kubeadmiral-member-2"} 1
kubeadmiral_controller_manager_cluster_joined_state{cluster_name="kubeadmiral-member-3"} 1
# HELP kubeadmiral_controller_manager_cluster_schedulable_nodes_total 
# TYPE kubeadmiral_controller_manager_cluster_schedulable_nodes_total gauge
kubeadmiral_controller_manager_cluster_schedulable_nodes_total{cluster_name="kubeadmiral-member-1"} 1
kubeadmiral_controller_manager_cluster_schedulable_nodes_total{cluster_name="kubeadmiral-member-2"} 1
kubeadmiral_controller_manager_cluster_schedulable_nodes_total{cluster_name="kubeadmiral-member-3"} 1
# HELP kubeadmiral_controller_manager_cluster_sync_status_duration_seconds_seconds 
# TYPE kubeadmiral_controller_manager_cluster_sync_status_duration_seconds_seconds summary
kubeadmiral_controller_manager_cluster_sync_status_duration_seconds_seconds{cluster_name="kubeadmiral-member-1",quantile="0.5"} 0.049269051
kubeadmiral_controller_manager_cluster_sync_status_duration_seconds_seconds{cluster_name="kubeadmiral-member-1",quantile="0.95"} 0.234076325
kubeadmiral_controller_manager_cluster_sync_status_duration_seconds_seconds{cluster_name="kubeadmiral-member-1",quantile="0.99"} 0.234076325
kubeadmiral_controller_manager_cluster_sync_status_duration_seconds_seconds_sum{cluster_name="kubeadmiral-member-1"} 1.969726718
kubeadmiral_controller_manager_cluster_sync_status_duration_seconds_seconds_count{cluster_name="kubeadmiral-member-1"} 26
kubeadmiral_controller_manager_cluster_sync_status_duration_seconds_seconds{cluster_name="kubeadmiral-member-2",quantile="0.5"} 0.063357662
kubeadmiral_controller_manager_cluster_sync_status_duration_seconds_seconds{cluster_name="kubeadmiral-member-2",quantile="0.95"} 0.207740015
kubeadmiral_controller_manager_cluster_sync_status_duration_seconds_seconds{cluster_name="kubeadmiral-member-2",quantile="0.99"} 0.207740015
kubeadmiral_controller_manager_cluster_sync_status_duration_seconds_seconds_sum{cluster_name="kubeadmiral-member-2"} 1.8967318360000003
kubeadmiral_controller_manager_cluster_sync_status_duration_seconds_seconds_count{cluster_name="kubeadmiral-member-2"} 26
kubeadmiral_controller_manager_cluster_sync_status_duration_seconds_seconds{cluster_name="kubeadmiral-member-3",quantile="0.5"} 0.056204847
kubeadmiral_controller_manager_cluster_sync_status_duration_seconds_seconds{cluster_name="kubeadmiral-member-3",quantile="0.95"} 0.09410731
kubeadmiral_controller_manager_cluster_sync_status_duration_seconds_seconds{cluster_name="kubeadmiral-member-3",quantile="0.99"} 0.09410731
kubeadmiral_controller_manager_cluster_sync_status_duration_seconds_seconds_sum{cluster_name="kubeadmiral-member-3"} 1.575615451
kubeadmiral_controller_manager_cluster_sync_status_duration_seconds_seconds_count{cluster_name="kubeadmiral-member-3"} 25

```