### PR TITLE
fix(scheduler): unable to get current replicas from federatedObject correctly

### DIFF
--- a/pkg/controllers/scheduler/schedulingunit.go
+++ b/pkg/controllers/scheduler/schedulingunit.go
@@ -176,8 +176,8 @@ func getCurrentReplicasFromObject(
 		}
 
 		for _, patch := range override.Patches {
-			if patch.Op == replicasPath && (patch.Op == overridePatchOpReplace || patch.Op == "") {
-				var replicas *int64
+			if patch.Path == replicasPath && (patch.Op == overridePatchOpReplace || patch.Op == "") {
+				replicas := new(int64)
 				if err := json.Unmarshal(patch.Value.Raw, replicas); err != nil {
 					continue
 				}


### PR DESCRIPTION
Fix bugs in `getCurrentReplicasFromObject` function of Scheduler:
- The wrong field is selected when validating replicasPath
- If the `json.Unmarshal` function receives nil, it will return an InvalidUnmarshalError

