### PR TITLE
feat(metric): add some metrics for follower and sync controller

### DIFF
--- a/pkg/controllers/follower/controller.go
+++ b/pkg/controllers/follower/controller.go
@@ -290,6 +290,11 @@ func (c *Controller) reconcileLeader(
 			}
 			return worker.StatusError
 		}
+
+		c.metrics.Store("followers_total", len(desiredFollowers),
+			stats.Tag{Name: "namespace", Value: key.namespace},
+			stats.Tag{Name: "name", Value: key.sourceName},
+			stats.Tag{Name: "resource", Value: key.sourceGK.String()})
 	}
 
 	c.cacheObservedFromLeaders.update(leader, desiredFollowers)
@@ -458,6 +463,10 @@ func (c *Controller) reconcileFollower(
 		)
 		return worker.StatusError
 	} else if updated {
+		c.metrics.Store("leaders_total", len(desiredLeaders),
+			stats.Tag{Name: "namespace", Value: key.namespace},
+			stats.Tag{Name: "name", Value: key.sourceName},
+			stats.Tag{Name: "resource", Value: key.sourceGK.String()})
 		keyedLogger.V(1).Info("Updated follower to sync with leaders")
 	}
 

--- a/pkg/controllers/sync/controller.go
+++ b/pkg/controllers/sync/controller.go
@@ -863,7 +863,7 @@ func (s *SyncController) handleDeletionInClusters(
 	}
 
 	keyedLogger.V(4).Info("Handle deletion in clusters", "clusters", strings.Join(syncedClusterNames, ","))
-	dispatcher := dispatch.NewUnmanagedDispatcher(s.getClusterClient, targetGVR, targetQualifiedName)
+	dispatcher := dispatch.NewUnmanagedDispatcher(s.getClusterClient, targetGVR, targetQualifiedName, s.metrics)
 	retrievalFailureClusters := []string{}
 	unreadyClusters := []string{}
 	for _, cluster := range syncedClusters {


### PR DESCRIPTION
- Add some metrics for the `follower controller`, test results:
```shell
# HELP kubeadmiral_controller_manager_followers_total 
# TYPE kubeadmiral_controller_manager_followers_total gauge
kubeadmiral_controller_manager_followers_total{name="echo-server-deployments.apps",namespace="default",resource="Deployment.apps"} 1
....
# HELP kubeadmiral_controller_manager_leaders_total 
# TYPE kubeadmiral_controller_manager_leaders_total gauge
kubeadmiral_controller_manager_leaders_total{name="echo-server-configmaps",namespace="default",resource="ConfigMap"} 1
...
```
- Add some metrics for the `sync controller`, test results:
```shell
# HELP kubeadmiral_controller_manager_workload_sync_error_total 
# TYPE kubeadmiral_controller_manager_workload_sync_error_total counter
kubeadmiral_controller_manager_workload_sync_error_total{cluster="kubeadmiral-member-2",error_type="UpdateFailed",name="echo-server",namespace="default",operation="update",resource="apps/v1, Kind=Deployment"} 4
...
# HELP kubeadmiral_controller_manager_workload_sync_duration_seconds_seconds 
# TYPE kubeadmiral_controller_manager_workload_sync_duration_seconds_seconds summary
kubeadmiral_controller_manager_workload_sync_duration_seconds_seconds{cluster="kubeadmiral-member-1",name="echo-server",namespace="default",operation="create",resource="/v1, Kind=ConfigMap",result="ok",quantile="0.5"} 0.039064232
kubeadmiral_controller_manager_workload_sync_duration_seconds_seconds{cluster="kubeadmiral-member-1",name="echo-server",namespace="default",operation="create",resource="/v1, Kind=ConfigMap",result="ok",quantile="0.95"} 0.039064232
kubeadmiral_controller_manager_workload_sync_duration_seconds_seconds{cluster="kubeadmiral-member-1",name="echo-server",namespace="default",operation="create",resource="/v1, Kind=ConfigMap",result="ok",quantile="0.99"} 0.039064232
kubeadmiral_controller_manager_workload_sync_duration_seconds_seconds_sum{cluster="kubeadmiral-member-1",name="echo-server",namespace="default",operation="create",resource="/v1, Kind=ConfigMap",result="ok"} 0.039064232
kubeadmiral_controller_manager_workload_sync_duration_seconds_seconds_count{cluster="kubeadmiral-member-1",name="echo-server",namespace="default",operation="create",resource="/v1, Kind=ConfigMap",result="ok"} 1
...
```