### PR TITLE
fix: deletion was blocked when other clusters are not ready

### DIFF
--- a/pkg/controllers/automigration/controller.go
+++ b/pkg/controllers/automigration/controller.go
@@ -269,7 +269,7 @@ func (c *Controller) reconcile(ctx context.Context, qualifiedName common.Qualifi
 		qualifiedName.Namespace,
 		qualifiedName.Name,
 	)
-	if err != nil {
+	if err != nil && !apierrors.IsNotFound(err) {
 		keyedLogger.Error(err, "Failed to get federated object from store")
 		return worker.StatusError
 	}

--- a/pkg/controllers/common/constants.go
+++ b/pkg/controllers/common/constants.go
@@ -100,6 +100,9 @@ const (
 	// DisableFollowingAnnotation indicates whether follower scheduling should be disabled for the follower object.
 	DisableFollowingAnnotation = DefaultPrefix + "disable-following"
 
+	// PendingSyncClustersAnnotation indicates clusters to be sync.
+	PendingSyncClustersAnnotation = InternalPrefix + "pending-sync-clusters"
+
 	// When a pod remains unschedulable beyond this threshold, it becomes eligible for automatic migration.
 	PodUnschedulableThresholdAnnotation = InternalPrefix + "pod-unschedulable-threshold"
 	// AutoMigrationInfoAnnotation contains auto migration information.

--- a/pkg/controllers/statusaggregator/controller.go
+++ b/pkg/controllers/statusaggregator/controller.go
@@ -324,7 +324,7 @@ func (a *StatusAggregator) reconcile(ctx context.Context, key reconcileKey) (sta
 		key.namespace,
 		federatedName,
 	)
-	if err != nil {
+	if err != nil && !apierrors.IsNotFound(err) {
 		logger.Error(err, "Failed to get object from store")
 		return worker.StatusError
 	}

--- a/pkg/controllers/sync/status/status.go
+++ b/pkg/controllers/sync/status/status.go
@@ -35,6 +35,7 @@ type CollectedPropagationStatus struct {
 	StatusMap        PropagationStatusMap
 	GenerationMap    map[string]int64
 	ResourcesUpdated bool
+	SyncOKClusters   []string
 }
 
 // SetFederatedStatus sets the conditions and clusters fields of the


### PR DESCRIPTION
An internal annotation `pending-sync-clusters` is introduced to record which member clusters the sync controller needs to deliver resources to. When the dispatch is successful, the record of the member cluster will be removed in 'pending-sync-clusters'. So unrelated clusters that are not ready will not prevent the deletion of federated resources.