### PR TITLE
fix: deletion was blocked when other clusters are not ready

### DIFF
--- a/pkg/apis/core/v1alpha1/types_federatedobject.go
+++ b/pkg/apis/core/v1alpha1/types_federatedobject.go
@@ -219,6 +219,7 @@ type PropagationStatusType string
 const (
 	ClusterPropagationOK PropagationStatusType = "OK"
 	WaitingForRemoval    PropagationStatusType = "WaitingForRemoval"
+	PendingCreate        PropagationStatusType = "PendingCreate"
 
 	// Cluster-specific errors
 

--- a/pkg/controllers/automigration/controller.go
+++ b/pkg/controllers/automigration/controller.go
@@ -269,7 +269,7 @@ func (c *Controller) reconcile(ctx context.Context, qualifiedName common.Qualifi
 		qualifiedName.Namespace,
 		qualifiedName.Name,
 	)
-	if err != nil {
+	if err != nil && !apierrors.IsNotFound(err) {
 		keyedLogger.Error(err, "Failed to get federated object from store")
 		return worker.StatusError
 	}

--- a/pkg/controllers/federatedcluster/clusterstatus.go
+++ b/pkg/controllers/federatedcluster/clusterstatus.go
@@ -148,11 +148,9 @@ func (c *FederatedClusterController) collectIndividualClusterStatus(
 	if isReadyStatusChanged(oldClusterStatus, readyStatus) {
 		switch readyStatus {
 		case corev1.ConditionTrue:
-			c.eventRecorder.Eventf(cluster, readyReason, readyMessage, "Cluster is ready")
-		case corev1.ConditionFalse:
-			c.eventRecorder.Eventf(cluster, readyReason, readyMessage, "Cluster is not ready")
-		case corev1.ConditionUnknown:
-			c.eventRecorder.Eventf(cluster, readyReason, readyMessage, "Cluster ready state is unknown")
+			c.eventRecorder.Eventf(cluster, corev1.EventTypeNormal, readyReason, readyMessage)
+		case corev1.ConditionFalse, corev1.ConditionUnknown:
+			c.eventRecorder.Eventf(cluster, corev1.EventTypeWarning, readyReason, readyMessage)
 		}
 	}
 

--- a/pkg/controllers/statusaggregator/controller.go
+++ b/pkg/controllers/statusaggregator/controller.go
@@ -324,7 +324,7 @@ func (a *StatusAggregator) reconcile(ctx context.Context, key reconcileKey) (sta
 		key.namespace,
 		federatedName,
 	)
-	if err != nil {
+	if err != nil && !apierrors.IsNotFound(err) {
 		logger.Error(err, "Failed to get object from store")
 		return worker.StatusError
 	}


### PR DESCRIPTION
Add PendingCreate status at first when sync controller works on new selected clusters. So we only need to check objects in these member clusters when we need to delete them.