### PR TITLE
Support gpu scheduling

### DIFF
--- a/pkg/controllers/scheduler/framework/plugins/clusterresources/fit.go
+++ b/pkg/controllers/scheduler/framework/plugins/clusterresources/fit.go
@@ -173,3 +173,29 @@ func calculateResourceAllocatableRequest(
 
 	return 0, 0
 }
+
+func getRelevantResources(su *framework.SchedulingUnit) []corev1.ResourceName {
+	resources := make([]corev1.ResourceName, 0, len(framework.DefaultRequestedRatioResources))
+	for resourceName := range framework.DefaultRequestedRatioResources {
+		if resourceName == corev1.ResourceCPU || resourceName == corev1.ResourceMemory ||
+			su.ResourceRequest.HasScalarResource(resourceName) {
+			resources = append(resources, resourceName)
+		}
+	}
+
+	return resources
+}
+
+func getAllocatableAndRequested(
+	su *framework.SchedulingUnit,
+	cluster *fedcorev1a1.FederatedCluster,
+	resources []corev1.ResourceName,
+) (framework.ResourceToValueMap, framework.ResourceToValueMap) {
+	requested := make(framework.ResourceToValueMap, len(resources))
+	allocatable := make(framework.ResourceToValueMap, len(resources))
+	for _, resourceName := range resources {
+		allocatable[resourceName], requested[resourceName] = calculateResourceAllocatableRequest(su, cluster, resourceName)
+	}
+
+	return allocatable, requested
+}

--- a/pkg/controllers/scheduler/framework/plugins/clusterresources/least_allocated_test.go
+++ b/pkg/controllers/scheduler/framework/plugins/clusterresources/least_allocated_test.go
@@ -24,9 +24,22 @@ import (
 	"context"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/api/resource"
+
 	fedcorev1a1 "github.com/kubewharf/kubeadmiral/pkg/apis/core/v1alpha1"
 	"github.com/kubewharf/kubeadmiral/pkg/controllers/scheduler/framework"
 )
+
+func schedulingUnitWithGPU(su *framework.SchedulingUnit, value int64) *framework.SchedulingUnit {
+	su.ResourceRequest.SetScalar(framework.ResourceGPU, value)
+	return su
+}
+
+func clusterWithGPU(fc *fedcorev1a1.FederatedCluster, allocatable, available int64) *fedcorev1a1.FederatedCluster {
+	fc.Status.Resources.Allocatable[framework.ResourceGPU] = *resource.NewQuantity(allocatable, resource.BinarySI)
+	fc.Status.Resources.Available[framework.ResourceGPU] = *resource.NewQuantity(available, resource.BinarySI)
+	return fc
+}
 
 func TestClusterResourcesLeastAllocated(t *testing.T) {
 	tests := []struct {
@@ -36,14 +49,14 @@ func TestClusterResourcesLeastAllocated(t *testing.T) {
 		expectedList framework.ClusterScoreList
 	}{
 		{
-			// Cluster1 scores (remaining resources) on 0-10 scale
+			// Cluster1 scores (remaining resources) on 0-100 scale
 			// CPU Fraction: 0 / 4000 = 0%
 			// Memory Fraction: 0 / 10000 = 0%
-			// Cluster1 Score: 10 - (0-0)*100 = 100
-			// Cluster2 scores (remaining resources) on 0-10 scale
+			// Cluster1 Score: (100 + 100)/ 2 = 100
+			// Cluster2 scores (remaining resources) on 0-100 scale
 			// CPU Fraction: 0 / 4000 = 0 %
 			// Memory Fraction: 0 / 10000 = 0%
-			// Cluster2 Score: 10 - (0-0)*100 = 100
+			// Cluster2 Score: (100 + 100) / 2 = 100
 			su: makeSchedulingUnit("su1", 0, 0),
 			clusters: []*fedcorev1a1.FederatedCluster{
 				makeCluster("cluster1", 4000, 10000, 4000, 10000),
@@ -56,14 +69,14 @@ func TestClusterResourcesLeastAllocated(t *testing.T) {
 			name: "nothing scheduled, nothing requested",
 		},
 		{
-			// Cluster1 scores on 0-10 scale
+			// Cluster1 scores on 0-100 scale
 			// CPU Fraction: 3000 / 4000= 75%
 			// Memory Fraction: 5000 / 10000 = 50%
-			// Cluster1 Score: 10 - (0.75-0.5)*100 = 75
-			// Cluster2 scores on 0-10 scale
-			// CPU Fraction: 3000 / 6000= 50%
-			// Memory Fraction: 5000/10000 = 50%
-			// Cluster2 Score: 10 - (0.5-0.5)*100 = 100
+			// Cluster1 Score: (25 + 50) / 2 = 37
+			// Cluster2 scores on 0-100 scale
+			// CPU Fraction: 3000 / 6000 = 50%
+			// Memory Fraction: 5000 / 10000 = 50%
+			// Cluster2 Score: (50 + 50) / 2  = 50
 			su: makeSchedulingUnit("su2", 3000, 5000),
 			clusters: []*fedcorev1a1.FederatedCluster{
 				makeCluster("cluster1", 4000, 10000, 4000, 10000),
@@ -74,6 +87,50 @@ func TestClusterResourcesLeastAllocated(t *testing.T) {
 				{Cluster: makeCluster("cluster2", 6000, 10000, 6000, 10000), Score: 50},
 			},
 			name: "nothing scheduled, resources requested, differently sized machines",
+		},
+		{
+			// Cluster1 scores on 0-100 scale
+			// CPU Fraction: 3000 / 4000= 75%
+			// Memory Fraction: 5000 / 10000 = 50%
+			// GPU Fraction: 5000 / 10000 = 50%
+			// Cluster1 Score: (25 + 50 + 50 * 4) / 6 = 45
+			// Cluster2 scores on 0-100 scale
+			// CPU Fraction: 3000 / 6000 = 50%
+			// Memory Fraction: 5000 / 10000 = 50%
+			// GPU Fraction: 5000 / 10000 = 50%
+			// Cluster2 Score: (50 + 50 + 50 * 4) / 6 = 50
+			su: schedulingUnitWithGPU(makeSchedulingUnit("su3", 3000, 5000), 5000),
+			clusters: []*fedcorev1a1.FederatedCluster{
+				clusterWithGPU(makeCluster("cluster1", 4000, 10000, 4000, 10000), 10000, 10000),
+				clusterWithGPU(makeCluster("cluster2", 6000, 10000, 6000, 10000), 10000, 10000),
+			},
+			expectedList: []framework.ClusterScore{
+				{Cluster: clusterWithGPU(makeCluster("cluster1", 4000, 10000, 4000, 10000), 10000, 10000), Score: 45},
+				{Cluster: clusterWithGPU(makeCluster("cluster2", 6000, 10000, 6000, 10000), 10000, 10000), Score: 50},
+			},
+			name: "nothing scheduled, resources requested with gpu, differently sized machines",
+		},
+		{
+			// Cluster1 scores on 0-100 scale
+			// CPU Fraction: 6000 / 10000 = 60%
+			// Memory Fraction: 5000 / 10000 = 50%
+			// GPU Fraction: 4000 / 10000 = 40%
+			// Cluster1 Score: (40 + 50 + 60 * 4) / 6 = 55
+			// Cluster2 scores on 0-100 scale
+			// CPU Fraction: 6000 / 15000 = 40%
+			// Memory Fraction: 5000 / 10000 = 50%
+			// GPU Fraction: 4000 / 6700 = 60%
+			// Cluster2 Score: (60 + 50 + 40 * 4) / 6 = 45
+			su: schedulingUnitWithGPU(makeSchedulingUnit("su4", 6000, 5000), 4000),
+			clusters: []*fedcorev1a1.FederatedCluster{
+				clusterWithGPU(makeCluster("cluster1", 10000, 10000, 10000, 10000), 10000, 10000),
+				clusterWithGPU(makeCluster("cluster2", 15000, 10000, 15000, 10000), 6700, 6700),
+			},
+			expectedList: []framework.ClusterScore{
+				{Cluster: clusterWithGPU(makeCluster("cluster1", 10000, 10000, 10000, 10000), 10000, 10000), Score: 55},
+				{Cluster: clusterWithGPU(makeCluster("cluster2", 15000, 10000, 15000, 10000), 6700, 6700), Score: 45},
+			},
+			name: "nothing scheduled, resources requested with gpu, differently sized machines, gpu fraction differs",
 		},
 	}
 

--- a/pkg/controllers/scheduler/framework/plugins/clusterresources/most_allocated.go
+++ b/pkg/controllers/scheduler/framework/plugins/clusterresources/most_allocated.go
@@ -49,19 +49,23 @@ func (pl *ClusterResourcesMostAllocated) Score(
 		return 0, framework.NewResult(framework.Error, err.Error())
 	}
 
-	requested := make(framework.ResourceToValueMap, len(framework.DefaultRequestedRatioResources))
-	allocatable := make(framework.ResourceToValueMap, len(framework.DefaultRequestedRatioResources))
-	for resource := range framework.DefaultRequestedRatioResources {
-		allocatable[resource], requested[resource] = calculateResourceAllocatableRequest(su, cluster, resource)
-	}
+	resources := getRelevantResources(su)
+	allocatable, requested := getAllocatableAndRequested(su, cluster, resources)
 
 	var score, weightSum int64
 	// most allocated score favors nodes with most requested resources.
 	// It calculates the percentage of memory and CPU requested by pods scheduled on the node, and prioritizes
 	// based on the maximum of the average of the fraction of requested to capacity.
-	// Details: (cpu(10 * sum(requested) / capacity) + memory(10 * sum(requested) / capacity)) / 2
-	for resource, weight := range framework.DefaultRequestedRatioResources {
+	// Details:
+	// (cpu((capacity-sum(requested))*100/capacity) * cpu_weight +
+	// memory((capacity-sum(requested))*100/capacity) * memory_weight) / (cpu_weight + memory_weight)
+	// Or with gpu
+	// (cpu((capacity-sum(requested))*100/capacity) * cpu_weight +
+	// memory((capacity-sum(requested))*100/capacity) * memory_weight +
+	// gpu((capacity-sum(requested))*100/capacity) * gpu_weight) / (cpu_weight + memory_weight + gpu_weight)
+	for _, resource := range resources {
 		resourceScore := mostRequestedScore(requested[resource], allocatable[resource])
+		weight := framework.DefaultRequestedRatioResources[resource]
 		score += resourceScore * weight
 		weightSum += weight
 	}
@@ -78,11 +82,11 @@ func (pl *ClusterResourcesMostAllocated) ScoreExtensions() framework.ScoreExtens
 	return nil
 }
 
-// The used capacity is calculated on a scale of 0-10
-// 0 being the lowest priority and 10 being the highest.
+// The used capacity is calculated on a scale of 0-100
+// 0 being the lowest priority and 100 being the highest.
 // The more resources are used the higher the score is. This function
 // is almost a reversed version of least_requested_priority.calculateUnusedScore
-// (10 - calculateUnusedScore). The main difference is in rounding. It was added to
+// (100 - calculateUnusedScore). The main difference is in rounding. It was added to
 // keep the final formula clean and not to modify the widely used (by users
 // in their default scheduling policies) calculateUsedScore.
 func mostRequestedScore(requested, capacity int64) int64 {

--- a/pkg/controllers/scheduler/framework/plugins/clusterresources/most_allocated_test.go
+++ b/pkg/controllers/scheduler/framework/plugins/clusterresources/most_allocated_test.go
@@ -36,14 +36,14 @@ func TestClusterResourcesMostAllocated(t *testing.T) {
 		expectedList framework.ClusterScoreList
 	}{
 		{
-			// Cluster1 scores (remaining resources) on 0-10 scale
+			// Cluster1 scores (remaining resources) on 0-100 scale
 			// CPU Fraction: 0 / 4000 = 0%
 			// Memory Fraction: 0 / 10000 = 0%
-			// Cluster1 Score: 10 - (0-0)*100 = 100
-			// Cluster2 scores (remaining resources) on 0-10 scale
+			// Cluster1 Score: (0 + 0) / 2 = 0
+			// Cluster2 scores (remaining resources) on 0-100 scale
 			// CPU Fraction: 0 / 4000 = 0 %
 			// Memory Fraction: 0 / 10000 = 0%
-			// Cluster2 Score: 10 - (0-0)*100 = 100
+			// Cluster2 Score: (0 + 0) / 2 = 0
 			su: makeSchedulingUnit("su1", 0, 0),
 			clusters: []*fedcorev1a1.FederatedCluster{
 				makeCluster("cluster1", 4000, 10000, 4000, 10000),
@@ -56,14 +56,14 @@ func TestClusterResourcesMostAllocated(t *testing.T) {
 			name: "nothing scheduled, nothing requested",
 		},
 		{
-			// Cluster1 scores on 0-10 scale
+			// Cluster1 scores on 0-100 scale
 			// CPU Fraction: 3000 / 4000= 75%
 			// Memory Fraction: 5000 / 10000 = 50%
-			// Cluster1 Score: 10 - (0.75-0.5)*100 = 75
-			// Cluster2 scores on 0-10 scale
-			// CPU Fraction: 3000 / 6000= 50%
-			// Memory Fraction: 5000/10000 = 50%
-			// Cluster2 Score: 10 - (0.5-0.5)*100 = 100
+			// Cluster1 Score: (75 + 50) / 2 = 62
+			// Cluster2 scores on 0-100 scale
+			// CPU Fraction: 3000 / 6000 = 50%
+			// Memory Fraction: 5000 / 10000 = 50%
+			// Cluster2 Score: (50 + 50) / 2 = 50
 			su: makeSchedulingUnit("su2", 3000, 5000),
 			clusters: []*fedcorev1a1.FederatedCluster{
 				makeCluster("cluster1", 4000, 10000, 4000, 10000),
@@ -74,6 +74,50 @@ func TestClusterResourcesMostAllocated(t *testing.T) {
 				{Cluster: makeCluster("cluster2", 6000, 10000, 6000, 10000), Score: 50},
 			},
 			name: "nothing scheduled, resources requested, differently sized machines",
+		},
+		{
+			// Cluster1 scores on 0-100 scale
+			// CPU Fraction: 3000 / 4000= 75%
+			// Memory Fraction: 5000 / 10000 = 50%
+			// GPU Fraction: 5000 / 10000 = 50%
+			// Cluster1 Score: (75 + 50 + 50 * 4) / 6 = 54
+			// Cluster2 scores on 0-100 scale
+			// CPU Fraction: 3000 / 6000 = 50%
+			// Memory Fraction: 5000 / 10000 = 50%
+			// GPU Fraction: 5000 / 10000 = 50%
+			// Cluster2 Score: (50 + 50 + 50 * 4) / 6 = 50
+			su: schedulingUnitWithGPU(makeSchedulingUnit("su3", 3000, 5000), 5000),
+			clusters: []*fedcorev1a1.FederatedCluster{
+				clusterWithGPU(makeCluster("cluster1", 4000, 10000, 4000, 10000), 10000, 10000),
+				clusterWithGPU(makeCluster("cluster2", 6000, 10000, 6000, 10000), 10000, 10000),
+			},
+			expectedList: []framework.ClusterScore{
+				{Cluster: clusterWithGPU(makeCluster("cluster1", 4000, 10000, 4000, 10000), 10000, 10000), Score: 54},
+				{Cluster: clusterWithGPU(makeCluster("cluster2", 6000, 10000, 6000, 10000), 10000, 10000), Score: 50},
+			},
+			name: "nothing scheduled, resources requested with gpu, differently sized machines",
+		},
+		{
+			// Cluster1 scores on 0-100 scale
+			// CPU Fraction: 6000 / 10000 = 60%
+			// Memory Fraction: 5000 / 10000 = 50%
+			// GPU Fraction: 4000 / 10000 = 40%
+			// Cluster1 Score: (60 + 50 + 40 * 4) / 6 = 45
+			// Cluster2 scores on 0-100 scale
+			// CPU Fraction: 6000 / 15000 = 40%
+			// Memory Fraction: 5000 / 10000 = 50%
+			// GPU Fraction: 4000 / 6600 = 60%
+			// Cluster2 Score: (40 + 50 + 60 * 4) / 6 = 55
+			su: schedulingUnitWithGPU(makeSchedulingUnit("su4", 6000, 5000), 4000),
+			clusters: []*fedcorev1a1.FederatedCluster{
+				clusterWithGPU(makeCluster("cluster1", 10000, 10000, 10000, 10000), 10000, 10000),
+				clusterWithGPU(makeCluster("cluster2", 15000, 10000, 15000, 10000), 6600, 6600),
+			},
+			expectedList: []framework.ClusterScore{
+				{Cluster: clusterWithGPU(makeCluster("cluster1", 10000, 10000, 10000, 10000), 10000, 10000), Score: 45},
+				{Cluster: clusterWithGPU(makeCluster("cluster2", 15000, 10000, 15000, 10000), 6600, 6600), Score: 55},
+			},
+			name: "nothing scheduled, resources requested with gpu, differently sized machines, gpu fraction differs",
 		},
 	}
 

--- a/pkg/controllers/scheduler/framework/plugins/rsp/rsp.go
+++ b/pkg/controllers/scheduler/framework/plugins/rsp/rsp.go
@@ -72,12 +72,16 @@ func (pl *ClusterCapacityWeight) ReplicaScheduling(
 
 	var schedulingWeights map[string]int64
 	if dynamicSchedulingEnabled {
+		resourceName := corev1.ResourceCPU
+		if su.ResourceRequest.HasScalarResource(framework.ResourceGPU) {
+			resourceName = framework.ResourceGPU
+		}
 		clusterAvailables := QueryClusterResource(clusters, availableResource)
 		if len(clusters) != len(clusterAvailables) {
 			return clusterReplicasList, framework.NewResult(framework.Error)
 		}
 
-		weightLimit, err := CalcWeightLimit(clusters, supplyLimitProportion)
+		weightLimit, err := CalcWeightLimit(clusters, resourceName, supplyLimitProportion)
 		if err != nil {
 			return clusterReplicasList, framework.NewResult(
 				framework.Error,
@@ -85,7 +89,7 @@ func (pl *ClusterCapacityWeight) ReplicaScheduling(
 			)
 		}
 
-		schedulingWeights, err = AvailableToPercentage(clusterAvailables, weightLimit)
+		schedulingWeights, err = AvailableToPercentage(clusterAvailables, resourceName, weightLimit)
 		if err != nil {
 			return clusterReplicasList, framework.NewResult(
 				framework.Error,
@@ -182,6 +186,7 @@ func (pl *ClusterCapacityWeight) ReplicaScheduling(
 
 func CalcWeightLimit(
 	clusters []*fedcorev1a1.FederatedCluster,
+	resourceName corev1.ResourceName,
 	supplyLimitRatio float64,
 ) (weightLimit map[string]int64, err error) {
 	allocatables := QueryClusterResource(clusters, allocatableResource)
@@ -191,8 +196,8 @@ func CalcWeightLimit(
 	}
 	sum := 0.0
 	for _, resources := range allocatables {
-		cpu := resources[corev1.ResourceCPU]
-		sum += float64(cpu.Value())
+		resourceQuantity := resources[resourceName]
+		sum += float64(resourceQuantity.Value())
 	}
 	weightLimit = make(map[string]int64)
 	if sum == 0 {
@@ -202,25 +207,26 @@ func CalcWeightLimit(
 		return
 	}
 	for member, resources := range allocatables {
-		cpu, ok := resources[corev1.ResourceCPU]
+		resourceQuantity, ok := resources[resourceName]
 		if !ok {
 			err = ErrNoCPUResource
 			return
 		}
-		weightLimit[member] = int64(math.Round(float64(cpu.Value()) / sum * sumWeight * supplyLimitRatio))
+		weightLimit[member] = int64(math.Round(float64(resourceQuantity.Value()) / sum * sumWeight * supplyLimitRatio))
 	}
 	return
 }
 
 func AvailableToPercentage(
 	clusterAvailables map[string]corev1.ResourceList,
+	resourceName corev1.ResourceName,
 	weightLimit map[string]int64,
 ) (clusterWeights map[string]int64, err error) {
 	sumAvailable := 0.0
 	for _, resources := range clusterAvailables {
-		cpu := resources[corev1.ResourceCPU]
-		if cpu.Value() > 0.0 {
-			sumAvailable += float64(cpu.Value())
+		resourceQuantity := resources[resourceName]
+		if resourceQuantity.Value() > 0.0 {
+			sumAvailable += float64(resourceQuantity.Value())
 		}
 	}
 
@@ -236,18 +242,18 @@ func AvailableToPercentage(
 	sumTmpWeight := int64(0)
 
 	for member, resources := range clusterAvailables {
-		cpu, ok := resources[corev1.ResourceCPU]
+		resourceQuantity, ok := resources[resourceName]
 		if !ok {
 			err = ErrNoCPUResource
 			return
 		}
 
-		cpuValue := float64(cpu.Value())
-		if cpuValue < 0.0 {
-			cpuValue = 0.0
+		resourceValue := float64(resourceQuantity.Value())
+		if resourceValue < 0.0 {
+			resourceValue = 0.0
 		}
 
-		weight := int64(math.Round(cpuValue / sumAvailable * sumWeight))
+		weight := int64(math.Round(resourceValue / sumAvailable * sumWeight))
 		if weight > weightLimit[member] {
 			weight = weightLimit[member]
 		}

--- a/pkg/controllers/scheduler/framework/plugins/rsp/rsp_test.go
+++ b/pkg/controllers/scheduler/framework/plugins/rsp/rsp_test.go
@@ -152,7 +152,7 @@ func TestCalcWeightLimit(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotWeightLimit, err := CalcWeightLimit(tt.args.clusters, tt.args.supplyLimitRatio)
+			gotWeightLimit, err := CalcWeightLimit(tt.args.clusters, corev1.ResourceCPU, tt.args.supplyLimitRatio)
 			if !tt.wantErr(t, err, fmt.Sprintf("CalcWeightLimit(%v)", tt.args.clusters)) {
 				return
 			}
@@ -170,7 +170,7 @@ func TestAvailableToPercentage(t *testing.T) {
 		return args{
 			clusterAvailables: QueryAvailable(clusters),
 			weightLimit: func() map[string]int64 {
-				weightLimit, _ := CalcWeightLimit(clusters, 1.0)
+				weightLimit, _ := CalcWeightLimit(clusters, corev1.ResourceCPU, 1.0)
 				return weightLimit
 			}(),
 		}
@@ -247,7 +247,7 @@ func TestAvailableToPercentage(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotClusterWeights, err := AvailableToPercentage(tt.args.clusterAvailables, tt.args.weightLimit)
+			gotClusterWeights, err := AvailableToPercentage(tt.args.clusterAvailables, corev1.ResourceCPU, tt.args.weightLimit)
 			if !tt.wantErr(
 				t,
 				err,

--- a/pkg/controllers/scheduler/framework/util.go
+++ b/pkg/controllers/scheduler/framework/util.go
@@ -33,6 +33,10 @@ import (
 	fedcorev1a1 "github.com/kubewharf/kubeadmiral/pkg/apis/core/v1alpha1"
 )
 
+const (
+	ResourceGPU = corev1.ResourceName("nvidia.com/gpu")
+)
+
 // For each of these resources, a pod that doesn't request the resource explicitly
 // will be treated as having requested the amount indicated below, for the purpose
 // of computing priority only. This ensures that when scheduling zero-request pods, such
@@ -59,7 +63,8 @@ const (
 
 // TODO(feature), make the RequestedRatioResources configable
 
-var DefaultRequestedRatioResources = ResourceToWeightMap{corev1.ResourceMemory: 1, corev1.ResourceCPU: 1}
+// DefaultRequestedRatioResources is an empirical value derived from practice.
+var DefaultRequestedRatioResources = ResourceToWeightMap{corev1.ResourceMemory: 1, corev1.ResourceCPU: 1, ResourceGPU: 4}
 
 type (
 	ResourceToValueMap  map[corev1.ResourceName]int64
@@ -243,6 +248,18 @@ func (r *Resource) SetMaxResource(rl corev1.ResourceList) {
 			}
 		}
 	}
+}
+
+// HasScalarResource checks if Resource has the given scalar resource.
+func (r *Resource) HasScalarResource(name corev1.ResourceName) bool {
+	if r.ScalarResources == nil {
+		return false
+	}
+
+	if _, exists := r.ScalarResources[name]; exists {
+		return true
+	}
+	return false
 }
 
 // resourceRequest = max(sum(podSpec.Containers), podSpec.InitContainers) + overHead

--- a/pkg/controllers/scheduler/schedulingtriggers.go
+++ b/pkg/controllers/scheduler/schedulingtriggers.go
@@ -26,7 +26,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
@@ -35,8 +34,6 @@ import (
 	"github.com/kubewharf/kubeadmiral/pkg/controllers/common"
 	"github.com/kubewharf/kubeadmiral/pkg/controllers/scheduler/framework"
 	"github.com/kubewharf/kubeadmiral/pkg/util/annotation"
-	podutil "github.com/kubewharf/kubeadmiral/pkg/util/pod"
-	resourceutil "github.com/kubewharf/kubeadmiral/pkg/util/resource"
 	utilunstructured "github.com/kubewharf/kubeadmiral/pkg/util/unstructured"
 )
 
@@ -352,22 +349,6 @@ func getReplicaCount(
 	}
 
 	return *value, nil
-}
-
-func getResourceRequest(
-	ftc *fedcorev1a1.FederatedTypeConfig,
-	fedObject fedcorev1a1.GenericFederatedObject,
-) (framework.Resource, error) {
-	gvk := ftc.GetSourceTypeGVK()
-	podSpec, err := podutil.GetResourcePodSpec(fedObject, gvk)
-	if err != nil {
-		if errors.Is(err, podutil.ErrUnknownTypeToGetPodSpec) {
-			return framework.Resource{}, nil
-		}
-		return framework.Resource{}, err
-	}
-	resource := resourceutil.GetPodResourceRequests(podSpec)
-	return *framework.NewResource(resource), nil
 }
 
 func getPolicySchedulingContentHash(policySpec *fedcorev1a1.PropagationPolicySpec) (string, error) {

--- a/pkg/controllers/scheduler/schedulingunit.go
+++ b/pkg/controllers/scheduler/schedulingunit.go
@@ -152,6 +152,17 @@ func schedulingUnitForFedObject(
 		schedulingUnit.MaxClusters = maxClustersOverride
 	}
 
+	resourceRequest, err := getResourceRequest(typeConfig, fedObject)
+	if err != nil {
+		return nil, err
+	}
+	gpuResourceRequest := &framework.Resource{}
+	if resourceRequest.HasScalarResource(framework.ResourceGPU) {
+		gpuResourceRequest.SetScalar(framework.ResourceGPU, resourceRequest.ScalarResources[framework.ResourceGPU])
+	}
+	// now we only consider the resource request of gpu
+	schedulingUnit.ResourceRequest = *gpuResourceRequest
+
 	return schedulingUnit, nil
 }
 

--- a/pkg/util/resource/resource.go
+++ b/pkg/util/resource/resource.go
@@ -45,6 +45,15 @@ func GetPodResourceRequests(podSpec *corev1.PodSpec) corev1.ResourceList {
 	reqs := make(corev1.ResourceList)
 
 	for _, container := range podSpec.Containers {
+		// If you specify a limit for a resource, but do not specify any request,
+		// and no admission-time mechanism has applied a default request for that resource,
+		// then Kubernetes copies the limit you specified and uses it as the requested value for the resource.
+		for resourceName, resourceLimits := range container.Resources.Limits {
+			if _, ok := container.Resources.Requests[resourceName]; !ok {
+				AddResources(corev1.ResourceList{resourceName: resourceLimits}, reqs)
+			}
+		}
+
 		AddResources(container.Resources.Requests, reqs)
 	}
 


### PR DESCRIPTION
This PR will:
* Pass in the gpu resource request into the scheduling unit
* `ClusterResourceFit` supports filter of gpu
* `MostAllocatable` and `LeastAllocatable` supports gpu resources, and the default weight map will be `cpu: memory: gpu=1:1:4`
* `BalancedAllocatable` supports comparison of GPU resources, based on standard deviation algorithm