### PR TITLE
fix(informer-manager): goroutine leak

### DIFF
--- a/pkg/util/informermanager/federatedinformermanager.go
+++ b/pkg/util/informermanager/federatedinformermanager.go
@@ -534,17 +534,6 @@ func (m *federatedInformerManager) Start(ctx context.Context) {
 		logger.V(2).Info("Stopping FederatedInformerManager")
 		m.queue.ShutDown()
 
-		// We explicitly cancel the contexts for any running managers to prevent goroutine leaks
-		for cluster, cancel := range m.clusterCancelFuncs {
-			klog.FromContext(ctx).V(2).Info(
-				"Stopping InformerManager and SharedInformerFactory for FederatedCluster",
-				"cluster",
-				cluster,
-			)
-			cancel()
-		}
-
-		// We also unregister the event handler for FederatedCluster to prevent goroutine leak
 		if m.clusterEventHandlerRegistration != nil {
 			logger.V(2).Info("Removing event handler for FederatedCluster")
 			if err := m.clusterInformer.Informer().RemoveEventHandler(m.clusterEventHandlerRegistration); err != nil {

--- a/pkg/util/informermanager/federatedinformermanager.go
+++ b/pkg/util/informermanager/federatedinformermanager.go
@@ -534,7 +534,17 @@ func (m *federatedInformerManager) Start(ctx context.Context) {
 		logger.V(2).Info("Stopping FederatedInformerManager")
 		m.queue.ShutDown()
 
-		// We unregister the event handler for FederatedCluster to prevent goroutine leak
+		// We explicitly cancel the contexts for any running managers to prevent goroutine leaks
+		for cluster, cancel := range m.clusterCancelFuncs {
+			klog.FromContext(ctx).V(2).Info(
+				"Stopping InformerManager and SharedInformerFactory for FederatedCluster",
+				"cluster",
+				cluster,
+			)
+			cancel()
+		}
+
+		// We also unregister the event handler for FederatedCluster to prevent goroutine leak
 		if m.clusterEventHandlerRegistration != nil {
 			logger.V(2).Info("Removing event handler for FederatedCluster")
 			if err := m.clusterInformer.Informer().RemoveEventHandler(m.clusterEventHandlerRegistration); err != nil {

--- a/pkg/util/informermanager/federatedinformermanager.go
+++ b/pkg/util/informermanager/federatedinformermanager.go
@@ -534,6 +534,7 @@ func (m *federatedInformerManager) Start(ctx context.Context) {
 		logger.V(2).Info("Stopping FederatedInformerManager")
 		m.queue.ShutDown()
 
+		// We unregister the event handler for FederatedCluster to prevent goroutine leak
 		if m.clusterEventHandlerRegistration != nil {
 			logger.V(2).Info("Removing event handler for FederatedCluster")
 			if err := m.clusterInformer.Informer().RemoveEventHandler(m.clusterEventHandlerRegistration); err != nil {

--- a/pkg/util/informermanager/federatedinformermanager.go
+++ b/pkg/util/informermanager/federatedinformermanager.go
@@ -534,6 +534,7 @@ func (m *federatedInformerManager) Start(ctx context.Context) {
 		logger.V(2).Info("Stopping FederatedInformerManager")
 		m.queue.ShutDown()
 
+		// We remove the event handler for FederatedCluster to prevent goroutine leak
 		if m.clusterEventHandlerRegistration != nil {
 			logger.V(2).Info("Removing event handler for FederatedCluster")
 			if err := m.clusterInformer.Informer().RemoveEventHandler(m.clusterEventHandlerRegistration); err != nil {

--- a/pkg/util/informermanager/informermanager.go
+++ b/pkg/util/informermanager/informermanager.go
@@ -410,13 +410,6 @@ func (m *informerManager) Start(ctx context.Context) {
 		logger.V(2).Info("Stopping InformerManager")
 		m.queue.ShutDown()
 
-		// We explicitly cancel the contexts for any running informers to prevent goroutine leaks
-		for ftc, cancel := range m.informerCancelFuncs {
-			logger.V(2).Info("Stopping informer for FederatedTypeConfig", "ftc", ftc)
-			cancel()
-		}
-
-		// We also unregister the event handler for FederatedTypeConfig to prevent goroutine leak
 		if m.ftcEventHandlerRegistration != nil {
 			logger.V(2).Info("Removing event handler FederatedTypeConfig")
 			if err := m.ftcInformer.Informer().RemoveEventHandler(m.ftcEventHandlerRegistration); err != nil {

--- a/pkg/util/informermanager/informermanager.go
+++ b/pkg/util/informermanager/informermanager.go
@@ -410,7 +410,7 @@ func (m *informerManager) Start(ctx context.Context) {
 		logger.V(2).Info("Stopping InformerManager")
 		m.queue.ShutDown()
 
-		// We must cancel the contexts for any running informers to prevent goroutine leaks
+		// We explicitly cancel the contexts for any running informers to prevent goroutine leaks
 		for ftc, cancel := range m.informerCancelFuncs {
 			logger.V(2).Info("Stopping informer for FederatedTypeConfig", "ftc", ftc)
 			cancel()

--- a/pkg/util/informermanager/informermanager.go
+++ b/pkg/util/informermanager/informermanager.go
@@ -244,6 +244,7 @@ func (m *informerManager) processFTC(
 			continue
 		}
 
+		// We remove the event handler for FederatedTypeConfig to prevent goroutine leak
 		if oldRegistration := registrations[generator]; oldRegistration != nil {
 			if err := informer.Informer().RemoveEventHandler(oldRegistration); err != nil {
 				return true, fmt.Errorf("failed to unregister event handler: %w", err)


### PR DESCRIPTION
There is a goroutine leak in the implementation of `InformerManager`. This is caused by the `InformerManager`'s handler for `FederatedTypeConfig` is not being unregistered upon stopping.

This results in a goroutine and memory leak as clusters are added and deleted.

Additionally, the `FederatedInformerManager` has also been modified to also unregister its event handler for `FederatedCluster` upon stopping.