### PR TITLE
feat: add fitError when no available clusters

### DIFF
--- a/pkg/controllers/scheduler/extensions/webhook/v1alpha1/plugin.go
+++ b/pkg/controllers/scheduler/extensions/webhook/v1alpha1/plugin.go
@@ -158,7 +158,7 @@ func (p *WebhookPlugin) Filter(
 	if resp.Selected {
 		return framework.NewResult(framework.Success)
 	} else {
-		return framework.NewResult(framework.Unschedulable)
+		return framework.NewResult(framework.Unschedulable, fmt.Sprintf("cluster(s) were filtered by webhookPlugin(%s)", p.name))
 	}
 }
 

--- a/pkg/controllers/scheduler/extensions/webhook/v1alpha1/plugin_test.go
+++ b/pkg/controllers/scheduler/extensions/webhook/v1alpha1/plugin_test.go
@@ -168,6 +168,9 @@ func TestFilter(t *testing.T) {
 			selected: true,
 		},
 		"webhook does not select cluster": {
+			webhookErrors: webhookErrors{
+				responseError: "cluster(s) were filtered by webhookPlugin(test)",
+			},
 			su:       getSampleSchedulingUnit(),
 			cluster:  getSampleCluster("test"),
 			selected: false,

--- a/pkg/controllers/scheduler/framework/plugins/apiresources/apiresources.go
+++ b/pkg/controllers/scheduler/framework/plugins/apiresources/apiresources.go
@@ -39,5 +39,5 @@ func (pl *APIResources) Filter(ctx context.Context, su *framework.SchedulingUnit
 			return framework.NewResult(framework.Success)
 		}
 	}
-	return framework.NewResult(framework.Unschedulable, "No matched group version kind.")
+	return framework.NewResult(framework.Unschedulable, "cluster(s) didn't support this APIVersion")
 }

--- a/pkg/controllers/scheduler/framework/plugins/apiresources/apiresources_test.go
+++ b/pkg/controllers/scheduler/framework/plugins/apiresources/apiresources_test.go
@@ -77,7 +77,7 @@ func TestAPIResourcesFilter(t *testing.T) {
 					Kind:    "Deployment",
 				},
 			}),
-			wantResult: framework.NewResult(framework.Unschedulable, "No matched group version kind."),
+			wantResult: framework.NewResult(framework.Unschedulable, "cluster(s) didn't support this APIVersion"),
 		},
 	}
 

--- a/pkg/controllers/scheduler/framework/plugins/clusterready/clusterready.go
+++ b/pkg/controllers/scheduler/framework/plugins/clusterready/clusterready.go
@@ -48,7 +48,7 @@ func (pl *ClusterReady) Filter(
 	// Prevent scheduling to unready cluster unless it is already scheduled to.
 	_, alreadyScheduled := su.CurrentClusters[cluster.Name]
 	if !alreadyScheduled && !clusterutil.IsClusterReady(&cluster.Status) {
-		return framework.NewResult(framework.Unschedulable, "cluster is unready")
+		return framework.NewResult(framework.Unschedulable, "cluster(s) were unready")
 	}
 
 	return framework.NewResult(framework.Success)

--- a/pkg/controllers/scheduler/framework/plugins/placement/filter.go
+++ b/pkg/controllers/scheduler/framework/plugins/placement/filter.go
@@ -50,7 +50,7 @@ func (pl *PlacementFilter) Filter(
 	}
 
 	if _, exists := su.ClusterNames[cluster.Name]; !exists {
-		return framework.NewResult(framework.Unschedulable, "cluster is not in placement list")
+		return framework.NewResult(framework.Unschedulable, "cluster(s) were not in placement list")
 	}
 
 	return framework.NewResult(framework.Success)

--- a/pkg/controllers/scheduler/framework/runtime/framework.go
+++ b/pkg/controllers/scheduler/framework/runtime/framework.go
@@ -143,6 +143,7 @@ func (f *frameworkImpl) RunFilterPlugins(
 	for _, pl := range f.filterPlugins {
 		pluginResult := f.runFilterPlugin(ctx, pl, schedulingUnit, cluster)
 		if !pluginResult.IsSuccess() {
+			pluginResult.SetFailedPlugin(pl.Name())
 			return pluginResult
 		}
 	}

--- a/pkg/controllers/scheduler/framework/runtime/framework_test.go
+++ b/pkg/controllers/scheduler/framework/runtime/framework_test.go
@@ -162,7 +162,7 @@ func TestRunFilterPlugins(t *testing.T) {
 				"a": getNaiveFilterPluginFactory(false),
 			},
 			&fedcore.EnabledPlugins{FilterPlugins: []string{"a"}},
-			framework.NewResult(framework.Error),
+			framework.NewResult(framework.Error).WithFailedPlugin("NaiveFilterPlugin"),
 		},
 		{
 			"multiple filter plugins, all succeed",
@@ -182,7 +182,7 @@ func TestRunFilterPlugins(t *testing.T) {
 				"c": getNaiveFilterPluginFactory(true),
 			},
 			&fedcore.EnabledPlugins{FilterPlugins: []string{"a", "b", "c"}},
-			framework.NewResult(framework.Error),
+			framework.NewResult(framework.Error).WithFailedPlugin("NaiveFilterPlugin"),
 		},
 		{
 			"multiple filter plugins, none succeed",
@@ -192,7 +192,7 @@ func TestRunFilterPlugins(t *testing.T) {
 				"c": getNaiveFilterPluginFactory(false),
 			},
 			&fedcore.EnabledPlugins{FilterPlugins: []string{"a", "b", "c"}},
-			framework.NewResult(framework.Error),
+			framework.NewResult(framework.Error).WithFailedPlugin("NaiveFilterPlugin"),
 		},
 	}
 


### PR DESCRIPTION
When there is no available clusters, scheduler will result in a `FitError`, and we can get the scheduling details from events.
```
 Warning  ScheduleFederatedObject  17m (x4 over 17m)     scheduler                  0/3 clusters are available: 1 cluster(s) didn't match cluster selector, 2 cluster(s) were not in placement list

```