### PR TITLE
feat: support force delete for federated cluster

### DIFF
--- a/pkg/util/cascadingdeletion/annotation.go
+++ b/pkg/util/cascadingdeletion/annotation.go
@@ -21,7 +21,7 @@ import (
 	"github.com/kubewharf/kubeadmiral/pkg/controllers/common"
 )
 
-// AnnotationCascadingDelete on a fedreated cluster means that
+// AnnotationCascadingDelete on a federated cluster means that
 // resources managed by KubeAdmiral in the cluster should be cleaned
 // up before deletion can occur.
 var AnnotationCascadingDelete = common.DefaultPrefix + "cascading-delete"


### PR DESCRIPTION
When attempting to delete a federated cluster, if it has the annotation **kubeadmiral.io/force-delete**, KubeAdmiral will forcefully delete the cluster.