### PR TITLE
ci: integrate the codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,22 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 2%
+    # https://docs.codecov.com/docs/commit-status#patch-status
+    patch:
+      default:
+        target: 60%
+        if_ci_failed: error
+# https://docs.codecov.com/docs/ignoring-paths
+ignore:
+  - "config"
+  - "docs"
+  - "examples"
+  - "hack"
+  - "pkg/apis"
+  - "pkg/client"
+  - "test"
+  - "*_test.go"
+  - "fake_*.go"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,6 @@ on:
       - v*
   pull_request:
 
-# TODO: coverage
-
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -26,7 +24,28 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
 
-      - run: make test
+      - name: Ensure coverage is reported for every package
+        run: |
+          find pkg -type d -print0 | while IFS= read -r -d '' dir; do
+            go_file=$(ls -1 $dir | grep '\.go$' | grep -v '_test\.go$' | head -n1)
+            if [[ $go_file ]]; then
+              package_line=$(grep '^package' ${dir}/${go_file} | head -n1)
+              echo "${package_line}_test" >$dir/package_coverage_test.go
+            fi
+          done
+
+      - name: Run unit tests
+        run: make test
+
+      - name: Upload coverage reports to Codecov
+        if: ${{ github.repository == 'kubewharf/kubeadmiral' && matrix.go-version == '1.19' }}
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.out
+          flags: unittests
+          fail_ci_if_error: true
+          verbose: true
 
   lint:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -147,10 +147,10 @@ lint-new: lint
 # Run tests
 .PHONY: test
 test:
-	go test -race -coverprofile coverage0.out ./pkg/...
+	go test -race -coverpkg=./pkg/... -coverprofile coverage.out.tmp ./pkg/...
 # exclude generated files from coverage calculation
-	sed '/generated/d' coverage0.out > coverage.out
-	rm coverage0.out
+	sed '/generated/d' coverage.out.tmp > coverage.out
+	rm coverage.out.tmp
 
 # Run e2e tests
 .PHONY: e2e


### PR DESCRIPTION
Add code coverage detection and ensure that **60%or higher of new code**  is covered with unit tests.

Currently we only focus on the coverage in the `./pkg` directory, and will ignore the following packages or files in this directory:
  - "pkg/apis"
  - "pkg/client"
  - "*_test.go"
  - "fake_*.go"