### PR TITLE
fix(core): incorrect type assertion to *cache.DeletedFinalStateUnknown

### DIFF
--- a/pkg/controllers/federate/controller.go
+++ b/pkg/controllers/federate/controller.go
@@ -125,7 +125,7 @@ func NewFederateController(
 		Generator: func(ftc *fedcorev1a1.FederatedTypeConfig) cache.ResourceEventHandler {
 			return cache.FilteringResourceEventHandler{
 				FilterFunc: func(obj interface{}) bool {
-					if deleted, ok := obj.(*cache.DeletedFinalStateUnknown); ok {
+					if deleted, ok := obj.(cache.DeletedFinalStateUnknown); ok {
 						obj = deleted.Obj
 					}
 					uns := obj.(*unstructured.Unstructured)
@@ -148,7 +148,7 @@ func NewFederateController(
 
 	if _, err := fedObjectInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: func(obj interface{}) bool {
-			if deleted, ok := obj.(*cache.DeletedFinalStateUnknown); ok {
+			if deleted, ok := obj.(cache.DeletedFinalStateUnknown); ok {
 				obj = deleted.Obj
 			}
 			fedObj := obj.(*fedcorev1a1.FederatedObject)

--- a/pkg/util/informermanager/federatedinformermanager.go
+++ b/pkg/util/informermanager/federatedinformermanager.go
@@ -510,7 +510,7 @@ func (m *federatedInformerManager) Start(ctx context.Context) {
 				}
 			},
 			DeleteFunc: func(obj interface{}) {
-				if deleted, ok := obj.(*cache.DeletedFinalStateUnknown); ok {
+				if deleted, ok := obj.(cache.DeletedFinalStateUnknown); ok {
 					obj = deleted.Obj
 					if obj == nil {
 						return


### PR DESCRIPTION
This fixes incorrect type assertions at various locations that result in the failure to catch when `cache.DeletedFinalStateUnknown` is emitted by the corresponding informer. The subsequent type assertions will then result in a panic.

Example:
<img width="1483" alt="image" src="https://github.com/kubewharf/kubeadmiral/assets/50948002/7cd54288-6591-4136-91d0-e0e3ddc538ec">
