### PR TITLE
fix(overridepolicy-controller): fix using deepEqual incorrectly 

### DIFF
--- a/pkg/controllers/override/overridepolicy_controller.go
+++ b/pkg/controllers/override/overridepolicy_controller.go
@@ -343,7 +343,7 @@ func (c *Controller) reconcile(ctx context.Context, qualifiedName common.Qualifi
 		return worker.StatusError
 	}
 
-	var overrides overridesMap
+	var overrides, currentOverrides overridesMap
 	// Apply overrides from each policy in order
 	for _, policy := range policies {
 		newOverrides, err := parseOverrides(policy, placedClusters, fedObject)
@@ -363,7 +363,8 @@ func (c *Controller) reconcile(ctx context.Context, qualifiedName common.Qualifi
 		overrides = mergeOverrides(overrides, newOverrides)
 	}
 
-	currentOverrides := fedObject.GetSpec().GetControllerOverrides(PrefixedControllerName)
+	currentOverridesList := fedObject.GetSpec().GetControllerOverrides(PrefixedControllerName)
+	currentOverrides = convertOverridesListToMap(currentOverridesList)
 	needsUpdate := !equality.Semantic.DeepEqual(overrides, currentOverrides)
 
 	if needsUpdate {

--- a/pkg/controllers/override/util.go
+++ b/pkg/controllers/override/util.go
@@ -325,3 +325,16 @@ func setOverrides(federatedObj fedcorev1a1.GenericFederatedObject, overridesMap 
 
 	return nil
 }
+
+func convertOverridesListToMap(overridesList []fedcorev1a1.ClusterReferenceWithPatches) overridesMap {
+	var ret overridesMap
+
+	for _, override := range overridesList {
+		if ret == nil {
+			ret = make(overridesMap)
+		}
+		ret[override.Cluster] = override.Patches
+	}
+
+	return ret
+}

--- a/pkg/controllers/override/util_test.go
+++ b/pkg/controllers/override/util_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package override
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 
@@ -1339,4 +1340,49 @@ func asJSON(value any) apiextensionsv1.JSON {
 		ret.Raw = data
 	}
 	return ret
+}
+
+func TestConvertOverridesListToMap(t *testing.T) {
+	tests := []struct {
+		name          string
+		overridesList []fedcorev1a1.ClusterReferenceWithPatches
+		expectedMap   overridesMap
+	}{
+		{
+			name:          "overrides is empty",
+			overridesList: nil,
+			expectedMap:   nil,
+		},
+		{
+			name: "overrides is not empty",
+			overridesList: []fedcorev1a1.ClusterReferenceWithPatches{
+				{
+					Cluster: "cluster1",
+					Patches: []fedcorev1a1.OverridePatch{
+						{
+							Op:    "replace",
+							Path:  "/spec/replicas",
+							Value: asJSON(2),
+						},
+					},
+				},
+			},
+			expectedMap: overridesMap{
+				"cluster1": []fedcorev1a1.OverridePatch{
+					{
+						Op:    "replace",
+						Path:  "/spec/replicas",
+						Value: asJSON(2),
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		actualMap := convertOverridesListToMap(tt.overridesList)
+		if !reflect.DeepEqual(tt.expectedMap, actualMap) {
+			t.Errorf("ConvertOverridesListToMap Error, expected: %+v, actual: %+v", tt.expectedMap, actualMap)
+		}
+	}
 }


### PR DESCRIPTION
Now we use the following statement to indicate whether overrides are updated.
```
needsUpdate := !equality.Semantic.DeepEqual(overrides, currentOverrides)
```
But overrides's type is `overridesMap`, whereas `currentOverrides` is a slice. So needsUpdate is always true which may lead to some useless updates.

BTW, I discovered that the resource had this event when I created the resource but did not associate the overrides policy which made me feel strange.
```
updated overrides according to override polic(ies)
```
After I deep into the codes, I found this mainly happens when fedobject needs to be updated. It has two situations:
* override policy updates
* pending annotation updates, e.g. we found no ops and removed the override-policy from pending controllers.

In the latter situation, event information is inaccurate. What do you think? /cc @gary-lgy @limhawjia @mrlihanbo 