### PR TITLE
fix(scheduler): prevents scheduling new replicas to terminating clusters

### DIFF
--- a/pkg/controllers/scheduler/framework/plugins/maxcluster/max_cluster.go
+++ b/pkg/controllers/scheduler/framework/plugins/maxcluster/max_cluster.go
@@ -50,6 +50,15 @@ func (pl *MaxCluster) SelectClusters(
 	}
 
 	sort.Slice(clusterScoreList, func(i, j int) bool {
+		if clusterScoreList[i].Cluster.DeletionTimestamp.IsZero() {
+			if clusterScoreList[j].Cluster.DeletionTimestamp.IsZero() {
+				return clusterScoreList[i].Score > clusterScoreList[j].Score
+			}
+			return true
+		}
+		if clusterScoreList[j].Cluster.DeletionTimestamp.IsZero() {
+			return false
+		}
 		return clusterScoreList[i].Score > clusterScoreList[j].Score
 	})
 

--- a/pkg/controllers/scheduler/scheduler.go
+++ b/pkg/controllers/scheduler/scheduler.go
@@ -535,7 +535,7 @@ func (s *Scheduler) schedule(
 		common.NewQualifiedName(policy).String(),
 	)
 
-	schedulingUnit, err := schedulingUnitForFedObject(ftc, fedObject, policy)
+	schedulingUnit, err := schedulingUnitForFedObject(ftc, fedObject, policy, clusters)
 	if err != nil {
 		logger.Error(err, "Failed to get scheduling unit")
 		s.eventRecorder.Eventf(

--- a/pkg/controllers/scheduler/scheduler_test.go
+++ b/pkg/controllers/scheduler/scheduler_test.go
@@ -129,7 +129,7 @@ func TestGetSchedulingUnit(t *testing.T) {
 		},
 	}
 
-	su, err := schedulingUnitForFedObject(typeConfig, &fedObj, &policy)
+	su, err := schedulingUnitForFedObject(typeConfig, &fedObj, &policy, nil)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
 	g.Expect(su).To(gomega.Equal(&framework.SchedulingUnit{
@@ -420,7 +420,7 @@ func TestGetSchedulingUnitWithAnnotationOverrides(t *testing.T) {
 					},
 				},
 			}
-			su, err := schedulingUnitForFedObject(typeConfig, obj, test.policy)
+			su, err := schedulingUnitForFedObject(typeConfig, obj, test.policy, nil)
 			g.Expect(err).NotTo(gomega.HaveOccurred())
 
 			// override fields we don't want to test
@@ -543,7 +543,7 @@ func TestSchedulingMode(t *testing.T) {
 			g.Expect(err).NotTo(gomega.HaveOccurred())
 			obj.Spec.Template.Raw = rawJSON
 
-			su, err := schedulingUnitForFedObject(typeConfig, obj, test.policy)
+			su, err := schedulingUnitForFedObject(typeConfig, obj, test.policy, nil)
 			g.Expect(err).NotTo(gomega.HaveOccurred())
 			g.Expect(su.SchedulingMode).To(gomega.Equal(test.expectedResult))
 		})

--- a/pkg/controllers/scheduler/schedulingunit_test.go
+++ b/pkg/controllers/scheduler/schedulingunit_test.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2023 The KubeAdmiral Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+
+	fedcorev1a1 "github.com/kubewharf/kubeadmiral/pkg/apis/core/v1alpha1"
+	"github.com/kubewharf/kubeadmiral/pkg/controllers/scheduler/framework"
+)
+
+func Test_updateMaxReplicasForTerminatingCluster(t *testing.T) {
+	type args struct {
+		su       *framework.SchedulingUnit
+		clusters []*fedcorev1a1.FederatedCluster
+	}
+	tests := []struct {
+		name            string
+		args            args
+		wantMaxReplicas map[string]int64
+	}{
+		{
+			name: "clusters is nil",
+			args: args{
+				su: &framework.SchedulingUnit{
+					CurrentClusters: map[string]*int64{
+						"cluster1": pointer.Int64(10),
+						"cluster2": pointer.Int64(5),
+					},
+				},
+				clusters: nil,
+			},
+			wantMaxReplicas: nil,
+		},
+		{
+			name: "no terminating cluster",
+			args: args{
+				su: &framework.SchedulingUnit{
+					CurrentClusters: map[string]*int64{
+						"cluster1": pointer.Int64(10),
+						"cluster2": pointer.Int64(5),
+					},
+					MaxReplicas: map[string]int64{
+						"cluster1": 1,
+						"cluster2": 2,
+					},
+				},
+				clusters: []*fedcorev1a1.FederatedCluster{
+					{ObjectMeta: metav1.ObjectMeta{Name: "cluster1"}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "cluster2"}},
+				},
+			},
+			wantMaxReplicas: map[string]int64{
+				"cluster1": 1,
+				"cluster2": 2,
+			},
+		},
+		{
+			name: "maxReplicas changed for terminating clusters",
+			args: args{
+				su: &framework.SchedulingUnit{
+					CurrentClusters: map[string]*int64{
+						"cluster1": pointer.Int64(1),
+						"cluster2": pointer.Int64(2),
+					},
+					MaxReplicas: map[string]int64{
+						"cluster1": 10,
+					},
+				},
+				clusters: []*fedcorev1a1.FederatedCluster{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:              "cluster1",
+							DeletionTimestamp: &metav1.Time{Time: time.Now()},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:              "cluster2",
+							DeletionTimestamp: &metav1.Time{Time: time.Now()},
+						},
+					},
+				},
+			},
+			wantMaxReplicas: map[string]int64{
+				"cluster1": 1,
+				"cluster2": 2,
+			},
+		},
+		{
+			name: "maxReplicas added for terminating clusters",
+			args: args{
+				su: &framework.SchedulingUnit{
+					CurrentClusters: map[string]*int64{
+						"cluster2": pointer.Int64(2),
+						"cluster3": pointer.Int64(2),
+					},
+				},
+				clusters: []*fedcorev1a1.FederatedCluster{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:              "cluster1",
+							DeletionTimestamp: &metav1.Time{Time: time.Now()},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:              "cluster2",
+							DeletionTimestamp: &metav1.Time{Time: time.Now()},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "cluster3",
+						},
+					},
+				},
+			},
+			wantMaxReplicas: map[string]int64{
+				"cluster1": 0,
+				"cluster2": 2,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			updateMaxReplicasForTerminatingCluster(tt.args.su, tt.args.clusters)
+			if !reflect.DeepEqual(tt.args.su.MaxReplicas, tt.wantMaxReplicas) {
+				t.Errorf("updateMaxReplicasForTerminatingCluster() got = %v, want %v",
+					tt.args.su.MaxReplicas, tt.wantMaxReplicas)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The current scheduler does not filter clusters being deleted because it may be necessary to retain resources in member clusters. However, this situation resulted in:
1. One member cluster is stuck in deletion
2. Workload is distributed using Divide mode
3. The deleting cluster has a high weight after `filter` and `score`.

**The scheduler may schedule new replicas to this terminating cluster.** However the sync controller will not dispatch resources to the terminating clusters. This will cause the workload to fail to scale up in federation.


This PR ensures that the terminating cluster will not scale up by setting `MaxReplicas` for the terminating cluster. Specifically:
* If the cluster being deleted has already been assigned replicas, the MaxReplicas is the currently assigned value.
* Otherwise, the MaxReplicas will be set to 0 to avoid creating new replicas in the terminating cluster.


When the `MaxClusters` exists at the same time, the scheduler will also give priority to non-terminated clusters when scheduling is triggered, specifically:
* If there are non-terminated clusters larger than MaxClusters, scheduling will be prioritized in these non-terminated clusters.
* When the number of non-terminating clusters is less than MaxClusters, the terminating cluster will still be selected by the scheduler. At this time, the number of replicas that can be scheduled will not more then the currently assigned value or be 0
