### PR TITLE
feat: support custom migration

### DIFF
--- a/config/crds/core.kubeadmiral.io_federatedtypeconfigs.yaml
+++ b/config/crds/core.kubeadmiral.io_federatedtypeconfigs.yaml
@@ -93,9 +93,12 @@ spec:
                     - version
                   type: object
                 statusAggregation:
-                  description: Configuration for StatusAggregation. If left empty, the StatusAggregation feature will be disabled.
+                  default:
+                    enabled: true
+                  description: Configuration for StatusAggregation.
                   properties:
                     enabled:
+                      default: true
                       description: Whether or not to enable status aggregation.
                       type: boolean
                   required:

--- a/config/sample/host/01-ftc.yaml
+++ b/config/sample/host/01-ftc.yaml
@@ -9,6 +9,8 @@ spec:
     pluralName: namespaces
     scope: Cluster
     version: v1
+  statusAggregation:
+    enabled: false
   controllers:
     - - kubeadmiral.io/nsautoprop-controller
     - - kubeadmiral.io/overridepolicy-controller
@@ -42,8 +44,6 @@ spec:
     pluralName: deployments
     scope: Namespaced
     version: v1
-  statusAggregation:
-    enabled: true
   autoMigration:
     enabled: true
   controllers:
@@ -297,8 +297,6 @@ spec:
     pluralName: jobs
     scope: Namespaced
     version: v1
-  statusAggregation:
-    enabled: true
   controllers:
     - - kubeadmiral.io/global-scheduler
     - - kubeadmiral.io/overridepolicy-controller

--- a/pkg/apis/core/v1alpha1/extensions_schedulingprofile.go
+++ b/pkg/apis/core/v1alpha1/extensions_schedulingprofile.go
@@ -29,6 +29,7 @@ func GetDefaultEnabledPlugins() *fedcore.EnabledPlugins {
 		names.ClusterAffinity,
 		names.ClusterReady,
 		names.ClusterTerminating,
+		names.ClusterEvicted,
 	}
 
 	scorePlugins := []string{

--- a/pkg/apis/core/v1alpha1/types_federatedtypeconfig.go
+++ b/pkg/apis/core/v1alpha1/types_federatedtypeconfig.go
@@ -53,8 +53,9 @@ type FederatedTypeConfigSpec struct {
 	// The API resource type to be federated.
 	SourceType APIResource `json:"sourceType"`
 
-	// Configuration for StatusAggregation. If left empty, the StatusAggregation feature will be disabled.
+	// Configuration for StatusAggregation.
 	// +optional
+	// +kubebuilder:default:={enabled:true}
 	StatusAggregation *StatusAggregationConfig `json:"statusAggregation,omitempty"`
 	// Configuration for StatusCollection. If left empty, the StatusCollection feature will be disabled.
 	// +optional
@@ -115,6 +116,7 @@ type StatusCollectionConfig struct {
 // StatusAggregationConfig defines the configurations for the StatusAggregation feature.
 type StatusAggregationConfig struct {
 	// Whether or not to enable status aggregation.
+	// +kubebuilder:default:=true
 	Enabled bool `json:"enabled"`
 }
 

--- a/pkg/controllers/common/constants.go
+++ b/pkg/controllers/common/constants.go
@@ -116,6 +116,11 @@ const (
 	TemplateGeneratorMergePatchAnnotation = FederateControllerPrefix + "template-generator-merge-patch"
 
 	LatestReplicasetDigestsAnnotation = DefaultPrefix + "latest-replicaset-digests"
+
+	// MigrationConfigurationAnnotation contains custom migration configuration from users.
+	MigrationConfigurationAnnotation = DefaultPrefix + "migration-configuration"
+	// AppliedMigrationConfigurationAnnotation contains the applied custom migration configuration.
+	AppliedMigrationConfigurationAnnotation = DefaultPrefix + "applied-migration-configuration"
 )
 
 // PropagatedAnnotationKeys and PropagatedLabelKeys are used to store the keys of annotations and labels that are present

--- a/pkg/controllers/federate/util.go
+++ b/pkg/controllers/federate/util.go
@@ -265,11 +265,13 @@ var (
 		scheduler.FollowsObjectAnnotation,
 		common.FollowersAnnotation,
 		common.DisableFollowingAnnotation,
+		common.MigrationConfigurationAnnotation,
 	)
 
 	// List of annotations that should be ignored on the source object
 	ignoredAnnotationSet = sets.New(
 		common.LatestReplicasetDigestsAnnotation,
+		common.AppliedMigrationConfigurationAnnotation,
 	)
 
 	federatedLabelSet = sets.New[string](

--- a/pkg/controllers/scheduler/constants.go
+++ b/pkg/controllers/scheduler/constants.go
@@ -41,10 +41,11 @@ const (
 
 	DefaultSchedulingMode = fedcorev1a1.SchedulingModeDuplicate
 
-	EventReasonScheduleFederatedObject   = "ScheduleFederatedObject"
-	EventReasonInvalidFollowsObject      = "InvalidFollowsObject"
-	EventReasonWebhookConfigurationError = "WebhookConfigurationError"
-	EventReasonWebhookRegistered         = "WebhookRegistered"
+	EventReasonScheduleFederatedObject     = "ScheduleFederatedObject"
+	EventReasonInvalidFollowsObject        = "InvalidFollowsObject"
+	EventReasonWebhookConfigurationError   = "WebhookConfigurationError"
+	EventReasonWebhookRegistered           = "WebhookRegistered"
+	EventReasonParseMigrationConfiguration = "ParseMigrationConfiguration"
 
 	SchedulingTriggersAnnotation        = common.DefaultPrefix + "scheduling-triggers"
 	SchedulingDeferredReasonsAnnotation = common.DefaultPrefix + "scheduling-deferred-reasons"

--- a/pkg/controllers/scheduler/framework/plugins/clusterevicted/cluster_evicted.go
+++ b/pkg/controllers/scheduler/framework/plugins/clusterevicted/cluster_evicted.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2023 The KubeAdmiral Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterevicted
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	fedcorev1a1 "github.com/kubewharf/kubeadmiral/pkg/apis/core/v1alpha1"
+	"github.com/kubewharf/kubeadmiral/pkg/controllers/scheduler/framework"
+	"github.com/kubewharf/kubeadmiral/pkg/controllers/scheduler/framework/plugins/names"
+)
+
+const (
+	// ErrReason for cluster evicted not matching.
+	ErrReason = "cluster(s) were evicted due to custom migration configuration"
+)
+
+type ClusterEvicted struct{}
+
+func NewClusterEvicted(_ framework.Handle) (framework.Plugin, error) {
+	return &ClusterEvicted{}, nil
+}
+
+func (pl *ClusterEvicted) Name() string {
+	return names.ClusterEvicted
+}
+
+// Filter invoked at the filter extension point.
+func (pl *ClusterEvicted) Filter(
+	ctx context.Context,
+	su *framework.SchedulingUnit,
+	cluster *fedcorev1a1.FederatedCluster,
+) *framework.Result {
+	err := framework.PreCheck(ctx, su, cluster)
+	if err != nil {
+		return framework.NewResult(framework.Error, err.Error())
+	}
+
+	if su.CustomMigration.Info != nil {
+		unavailableClusters := su.CustomMigration.Info.UnavailableClusters
+		for _, unavailableCluster := range unavailableClusters {
+			if cluster.Name == unavailableCluster.Cluster && metav1.Now().Time.Before(unavailableCluster.ValidUntil.Time) {
+				return framework.NewResult(framework.Unschedulable, ErrReason)
+			}
+		}
+	}
+
+	return framework.NewResult(framework.Success)
+}

--- a/pkg/controllers/scheduler/framework/plugins/clusterevicted/cluster_evicted_test.go
+++ b/pkg/controllers/scheduler/framework/plugins/clusterevicted/cluster_evicted_test.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+This file may have been modified by The KubeAdmiral Authors
+("KubeAdmiral Modifications"). All KubeAdmiral Modifications
+are Copyright 2023 The KubeAdmiral Authors.
+*/
+
+package clusterevicted
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	fedcorev1a1 "github.com/kubewharf/kubeadmiral/pkg/apis/core/v1alpha1"
+	"github.com/kubewharf/kubeadmiral/pkg/controllers/scheduler/framework"
+	"github.com/kubewharf/kubeadmiral/pkg/controllers/scheduler/framework/plugins/names"
+)
+
+func makeCluster(clusterName string) *fedcorev1a1.FederatedCluster {
+	return &fedcorev1a1.FederatedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: clusterName,
+		},
+	}
+}
+
+func TestName(t *testing.T) {
+	p, _ := NewClusterEvicted(nil)
+	if name := p.Name(); !reflect.DeepEqual(name, names.ClusterEvicted) {
+		t.Errorf("Expected name %s, but got %s", names.ClusterEvicted, name)
+	}
+}
+
+func TestClusterEvictedPlugin(t *testing.T) {
+	tests := []struct {
+		name           string
+		su             *framework.SchedulingUnit
+		cluster        *fedcorev1a1.FederatedCluster
+		expectedResult *framework.Result
+	}{
+		{
+			name:           "su is nil",
+			su:             nil,
+			cluster:        makeCluster("cluster1"),
+			expectedResult: framework.NewResult(framework.Error),
+		},
+		{
+			"cluster should not be filtered when custom migration info is empty",
+			&framework.SchedulingUnit{
+				CustomMigration: framework.CustomMigrationSpec{
+					Info: nil,
+				},
+			},
+			makeCluster("cluster1"),
+			framework.NewResult(framework.Success),
+		},
+		{
+			"cluster should not be filtered when name not in custom migration info",
+			&framework.SchedulingUnit{
+				CustomMigration: framework.CustomMigrationSpec{
+					Info: &framework.CustomMigrationInfo{
+						UnavailableClusters: []framework.UnavailableCluster{
+							{
+								Cluster: "cluster2",
+							},
+						},
+					},
+				},
+			},
+			makeCluster("cluster1"),
+			framework.NewResult(framework.Success),
+		},
+		{
+			"cluster should not be filtered when replica migration in custom migration info",
+			&framework.SchedulingUnit{
+				CustomMigration: framework.CustomMigrationSpec{
+					Info: &framework.CustomMigrationInfo{
+						LimitedCapacity: map[string]int64{
+							"cluster1": 1,
+						},
+					},
+				},
+			},
+			makeCluster("cluster1"),
+			framework.NewResult(framework.Success),
+		},
+		{
+			name: "cluster should not be filtered when time has expired",
+			su: &framework.SchedulingUnit{
+				CustomMigration: framework.CustomMigrationSpec{
+					Info: &framework.CustomMigrationInfo{
+						UnavailableClusters: []framework.UnavailableCluster{
+							{
+								Cluster: "cluster1",
+								ValidUntil: metav1.Time{
+									Time: time.Now().Add(-1 * time.Hour),
+								},
+							},
+						},
+					},
+				},
+			},
+			cluster:        makeCluster("cluster1"),
+			expectedResult: framework.NewResult(framework.Success),
+		},
+		{
+			name: "cluster should be filtered",
+			su: &framework.SchedulingUnit{
+				CustomMigration: framework.CustomMigrationSpec{
+					Info: &framework.CustomMigrationInfo{
+						UnavailableClusters: []framework.UnavailableCluster{
+							{
+								Cluster: "cluster1",
+								ValidUntil: metav1.Time{
+									Time: time.Now().Add(1 * time.Hour),
+								},
+							},
+						},
+					},
+				},
+			},
+			cluster:        makeCluster("cluster1"),
+			expectedResult: framework.NewResult(framework.Unschedulable),
+		},
+	}
+
+	p, _ := NewClusterEvicted(nil)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := p.(framework.FilterPlugin).Filter(context.TODO(), test.su, test.cluster)
+			if result.IsSuccess() != test.expectedResult.IsSuccess() {
+				t.Errorf("result does not match: %v, want %v", result, test.expectedResult)
+			}
+		})
+	}
+}

--- a/pkg/controllers/scheduler/framework/plugins/names/names.go
+++ b/pkg/controllers/scheduler/framework/plugins/names/names.go
@@ -29,4 +29,5 @@ const (
 	ClusterResourcesMostAllocated      = "ClusterResourcesMostAllocated"
 	MaxCluster                         = "MaxCluster"
 	ClusterCapacityWeight              = "ClusterCapacityWeight"
+	ClusterEvicted                     = "ClusterEvicted"
 )

--- a/pkg/controllers/scheduler/framework/plugins/rsp/rsp.go
+++ b/pkg/controllers/scheduler/framework/plugins/rsp/rsp.go
@@ -153,6 +153,11 @@ func (pl *ClusterCapacityWeight) ReplicaScheduling(
 		}
 	}
 
+	limitedCapacity := map[string]int64{}
+	if su.CustomMigration.Info != nil && su.CustomMigration.Info.LimitedCapacity != nil {
+		limitedCapacity = su.CustomMigration.Info.LimitedCapacity
+	}
+
 	scheduleResult, overflow, err := planner.Plan(
 		&planner.ReplicaSchedulingPreference{
 			Clusters: clusterPreferences,
@@ -161,6 +166,7 @@ func (pl *ClusterCapacityWeight) ReplicaScheduling(
 		ExtractClusterNames(clusters),
 		currentReplicas,
 		estimatedCapacity,
+		limitedCapacity,
 		su.Key(),
 		su.AvoidDisruption,
 		keepUnschedulableReplicas,

--- a/pkg/controllers/scheduler/profile.go
+++ b/pkg/controllers/scheduler/profile.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kubewharf/kubeadmiral/pkg/controllers/scheduler/framework"
 	"github.com/kubewharf/kubeadmiral/pkg/controllers/scheduler/framework/plugins/apiresources"
 	"github.com/kubewharf/kubeadmiral/pkg/controllers/scheduler/framework/plugins/clusteraffinity"
+	"github.com/kubewharf/kubeadmiral/pkg/controllers/scheduler/framework/plugins/clusterevicted"
 	"github.com/kubewharf/kubeadmiral/pkg/controllers/scheduler/framework/plugins/clusterready"
 	"github.com/kubewharf/kubeadmiral/pkg/controllers/scheduler/framework/plugins/clusterresources"
 	"github.com/kubewharf/kubeadmiral/pkg/controllers/scheduler/framework/plugins/clusterterminating"
@@ -51,6 +52,7 @@ var inTreeRegistry = runtime.Registry{
 	names.ClusterResourcesMostAllocated:      clusterresources.NewClusterResourcesMostAllocated,
 	names.MaxCluster:                         maxcluster.NewMaxCluster,
 	names.ClusterCapacityWeight:              rsp.NewClusterCapacityWeight,
+	names.ClusterEvicted:                     clusterevicted.NewClusterEvicted,
 }
 
 func applyProfile(base *fedcore.EnabledPlugins, profile *fedcorev1a1.SchedulingProfile) {

--- a/pkg/controllers/scheduler/schedulingtriggers.go
+++ b/pkg/controllers/scheduler/schedulingtriggers.go
@@ -303,6 +303,7 @@ var knownSchedulingAnnotations = sets.New(
 	AffinityAnnotations,
 	MaxClustersAnnotations,
 	FollowsObjectAnnotation,
+	common.AppliedMigrationConfigurationAnnotation,
 )
 
 func getSchedulingAnnotationsHash(fedObject fedcorev1a1.GenericFederatedObject) (string, error) {

--- a/pkg/controllers/scheduler/schedulingunit.go
+++ b/pkg/controllers/scheduler/schedulingunit.go
@@ -94,6 +94,14 @@ func schedulingUnitForFedObject(
 		}
 	}
 
+	info, err := getCustomMigrationInfo(fedObject)
+	if err != nil {
+		return nil, err
+	}
+	schedulingUnit.CustomMigration = framework.CustomMigrationSpec{
+		Info: info,
+	}
+
 	schedulingUnit.AvoidDisruption = getAvoidDisruptionFromPolicy(policy)
 
 	schedulingUnit.SchedulingMode = schedulingMode
@@ -249,6 +257,19 @@ func getAutoMigrationInfo(fedObject fedcorev1a1.GenericFederatedObject) (*framew
 		return nil, err
 	}
 	return autoMigrationInfo, nil
+}
+
+func getCustomMigrationInfo(fedObject fedcorev1a1.GenericFederatedObject) (*framework.CustomMigrationInfo, error) {
+	value, exists := fedObject.GetAnnotations()[common.AppliedMigrationConfigurationAnnotation]
+	if !exists {
+		return nil, nil
+	}
+
+	customMigrationInfo := new(framework.CustomMigrationInfo)
+	if err := json.Unmarshal([]byte(value), customMigrationInfo); err != nil {
+		return nil, err
+	}
+	return customMigrationInfo, nil
 }
 
 func getIsStickyClusterFromPolicy(policy fedcorev1a1.GenericPropagationPolicy) bool {

--- a/pkg/controllers/scheduler/schedulingunit_test.go
+++ b/pkg/controllers/scheduler/schedulingunit_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2023 The KubeAdmiral Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"reflect"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	fedcorev1a1 "github.com/kubewharf/kubeadmiral/pkg/apis/core/v1alpha1"
+	"github.com/kubewharf/kubeadmiral/pkg/controllers/common"
+	"github.com/kubewharf/kubeadmiral/pkg/controllers/scheduler/framework"
+)
+
+func Test_getCustomMigrationInfo(t *testing.T) {
+	tests := []struct {
+		name      string
+		fedObject fedcorev1a1.GenericFederatedObject
+		want      *framework.CustomMigrationInfo
+	}{
+		{
+			name: "get custom migration info",
+			fedObject: &fedcorev1a1.FederatedObject{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						common.AppliedMigrationConfigurationAnnotation: "{\"limitedCapacity\":{\"cluster1\":1,\"cluster2\":2}}",
+					},
+				},
+			},
+			want: &framework.CustomMigrationInfo{
+				LimitedCapacity: map[string]int64{
+					"cluster1": 1,
+					"cluster2": 2,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got, _ := getCustomMigrationInfo(test.fedObject); !reflect.DeepEqual(got, test.want) {
+				t.Errorf("getCustomMigrationInfo() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}

--- a/pkg/controllers/statusaggregator/plugins/common/migrationconfig.go
+++ b/pkg/controllers/statusaggregator/plugins/common/migrationconfig.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2023 The KubeAdmiral Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+	"reflect"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	fedcorev1a1 "github.com/kubewharf/kubeadmiral/pkg/apis/core/v1alpha1"
+	"github.com/kubewharf/kubeadmiral/pkg/controllers/common"
+)
+
+type MigrationConfigPlugin struct{}
+
+func NewMigrationConfigPlugin() *MigrationConfigPlugin {
+	return &MigrationConfigPlugin{}
+}
+
+// TODO: Create a new interface that is different from the original `AggregateStatuses`
+func (receiver *MigrationConfigPlugin) AggregateStatuses(
+	ctx context.Context,
+	sourceObject *unstructured.Unstructured,
+	fedObject fedcorev1a1.GenericFederatedObject,
+	clusterObjs map[string]interface{},
+	clusterObjsUpToDate bool,
+) (*unstructured.Unstructured, bool, error) {
+	needUpdate := false
+
+	fedObjMigrationConfig, fedAnnotationExists := fedObject.GetAnnotations()[common.AppliedMigrationConfigurationAnnotation]
+	if sourceObject.GetAnnotations() == nil {
+		if fedAnnotationExists {
+			newAnnotation := make(map[string]string, 1)
+			newAnnotation[common.AppliedMigrationConfigurationAnnotation] = fedObjMigrationConfig
+			sourceObject.SetAnnotations(newAnnotation)
+			needUpdate = true
+		}
+		return sourceObject, needUpdate, nil
+	}
+	sourceObjMigrationConfig, sourceAnnotationExists := sourceObject.GetAnnotations()[common.AppliedMigrationConfigurationAnnotation]
+
+	// update annotations of source object if needed
+	if !fedAnnotationExists && sourceAnnotationExists {
+		updatedAnnotation := sourceObject.GetAnnotations()
+		delete(updatedAnnotation, common.AppliedMigrationConfigurationAnnotation)
+		sourceObject.SetAnnotations(updatedAnnotation)
+		needUpdate = true
+	}
+
+	if fedAnnotationExists && !reflect.DeepEqual(sourceObjMigrationConfig, fedObjMigrationConfig) {
+		updatedAnnotation := sourceObject.GetAnnotations()
+		updatedAnnotation[common.AppliedMigrationConfigurationAnnotation] = fedObjMigrationConfig
+		sourceObject.SetAnnotations(updatedAnnotation)
+		needUpdate = true
+	}
+
+	return sourceObject, needUpdate, nil
+}

--- a/pkg/controllers/statusaggregator/plugins/common/migrationconfig_test.go
+++ b/pkg/controllers/statusaggregator/plugins/common/migrationconfig_test.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2023 The KubeAdmiral Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	batchv1 "k8s.io/api/batch/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
+
+	fedcorev1a1 "github.com/kubewharf/kubeadmiral/pkg/apis/core/v1alpha1"
+	"github.com/kubewharf/kubeadmiral/pkg/controllers/common"
+)
+
+const testValue = "{\"unavailableClusters\":[{\"cluster\":\"kubeadmiral-member-1\",\"validUntil\":\"2023-11-24T07:12:52Z\"}]}"
+
+func generateFedObj(workload *unstructured.Unstructured) *fedcorev1a1.FederatedObject {
+	rawTargetTemplate, _ := workload.MarshalJSON()
+	return &fedcorev1a1.FederatedObject{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{},
+			Generation:  1,
+		},
+		Spec: fedcorev1a1.GenericFederatedObjectSpec{
+			Template: apiextensionsv1.JSON{Raw: rawTargetTemplate},
+		},
+	}
+}
+
+func TestMigrationConfigPlugin(t *testing.T) {
+	jobWithoutAnno := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "completed",
+			Namespace:   "default",
+			Annotations: map[string]string{},
+		},
+		Status: batchv1.JobStatus{
+			Active:    1,
+			Succeeded: 1,
+			Failed:    1,
+		},
+	}
+	jobWithAnno := jobWithoutAnno.DeepCopy()
+	jobWithAnno.Annotations[common.AppliedMigrationConfigurationAnnotation] = testValue
+	jobEmptyAnnos := jobWithoutAnno.DeepCopy()
+	jobEmptyAnnos.Annotations = nil
+
+	u1, err := runtime.DefaultUnstructuredConverter.ToUnstructured(jobWithoutAnno)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	unstructuredJobWithoutAnno := &unstructured.Unstructured{Object: u1}
+	fedObjWithoutAnno := generateFedObj(unstructuredJobWithoutAnno)
+
+	u2, err := runtime.DefaultUnstructuredConverter.ToUnstructured(jobWithAnno)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	unstructuredJobWithAnno := &unstructured.Unstructured{Object: u2}
+	fedObjWithAnno := fedObjWithoutAnno.DeepCopy()
+	fedObjWithAnno.Annotations[common.AppliedMigrationConfigurationAnnotation] = ""
+
+	u3, err := runtime.DefaultUnstructuredConverter.ToUnstructured(jobEmptyAnnos)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	unstructuredJobEmptyAnnos := &unstructured.Unstructured{Object: u3}
+
+	ctx := klog.NewContext(context.Background(), klog.Background())
+	receiver := NewMigrationConfigPlugin()
+
+	tests := []struct {
+		name           string
+		sourceObj      *unstructured.Unstructured
+		fedObj         *fedcorev1a1.FederatedObject
+		wantNeedUpdate bool
+	}{
+		{
+			name:           "sourceObj without anno, fedObj with anno",
+			sourceObj:      unstructuredJobWithoutAnno,
+			fedObj:         fedObjWithAnno,
+			wantNeedUpdate: true,
+		},
+		{
+			name:           "sourceObj with empty anno, fedObj with anno",
+			sourceObj:      unstructuredJobEmptyAnnos,
+			fedObj:         fedObjWithAnno,
+			wantNeedUpdate: true,
+		},
+		{
+			name:           "sourceObj with anno, fedObj with anno",
+			sourceObj:      unstructuredJobWithAnno,
+			fedObj:         fedObjWithAnno,
+			wantNeedUpdate: true,
+		},
+		{
+			name:           "sourceObj with anno, fedObj without anno",
+			sourceObj:      unstructuredJobWithAnno,
+			fedObj:         fedObjWithoutAnno,
+			wantNeedUpdate: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, needUpdate, _ := receiver.AggregateStatuses(ctx, tt.sourceObj, tt.fedObj, nil, false)
+			if !reflect.DeepEqual(needUpdate, tt.wantNeedUpdate) {
+				t.Errorf("AggregateStatuses = %v, want %v", needUpdate, tt.wantNeedUpdate)
+			}
+		})
+	}
+}

--- a/pkg/controllers/statusaggregator/plugins/plugin.go
+++ b/pkg/controllers/statusaggregator/plugins/plugin.go
@@ -27,6 +27,7 @@ import (
 
 	fedcorev1a1 "github.com/kubewharf/kubeadmiral/pkg/apis/core/v1alpha1"
 	"github.com/kubewharf/kubeadmiral/pkg/controllers/common"
+	plugincommon "github.com/kubewharf/kubeadmiral/pkg/controllers/statusaggregator/plugins/common"
 )
 
 type Plugin interface {
@@ -45,6 +46,10 @@ var pluginsMap = map[schema.GroupVersionKind]Plugin{
 	appsv1.SchemeGroupVersion.WithKind(common.StatefulSetKind): NewSingleClusterPlugin(),
 	batchv1.SchemeGroupVersion.WithKind(common.JobKind):        NewJobPlugin(),
 	corev1.SchemeGroupVersion.WithKind(common.PodKind):         NewPodPlugin(),
+}
+
+var DefaultCommonPlugins = []Plugin{
+	plugincommon.NewMigrationConfigPlugin(),
 }
 
 func GetPlugin(gvk schema.GroupVersionKind) Plugin {


### PR DESCRIPTION
To support custom migration we define three types of annotations:
* `kubeadmiral.io/migration-info` on source object: User-entered migration strategy.
* `kubeadmiral.io/latest-migration-info` on source object: The current migration strategy in effect, read-only.

Test Results:
1. WorkloadMigration:
Before migration:
![image](https://github.com/kubewharf/kubeadmiral/assets/26862112/882f7316-b048-4ac1-9342-5c1e12e3d384)
Add migration info anno:
![image](https://github.com/kubewharf/kubeadmiral/assets/26862112/d1a21e41-6bb8-4cad-af21-d3783358a286)

After migration:
SourceObj:
![image](https://github.com/kubewharf/kubeadmiral/assets/26862112/95abd0ed-f4ef-4bd0-acc9-d54a9e72c68e)
FedObj:
![image](https://github.com/kubewharf/kubeadmiral/assets/26862112/619c7093-c3bc-4d95-9317-e130e37a754b)

2. ReplicasMigration:
Before migration:
![image](https://github.com/kubewharf/kubeadmiral/assets/26862112/882f7316-b048-4ac1-9342-5c1e12e3d384)
Add migration info anno:
![image](https://github.com/kubewharf/kubeadmiral/assets/26862112/d72d969f-a5da-4836-8cfd-21e7dfbd40cc)

After migration:
SourceObj:
![image](https://github.com/kubewharf/kubeadmiral/assets/26862112/c81bb890-df44-41e8-8695-9c4e30fe996a)
FedObj:
![image](https://github.com/kubewharf/kubeadmiral/assets/26862112/939c75b1-9599-43e1-993c-d4e0d4da4365)

