### PR TITLE
feat: disable clusterResourcesFit by default

### DIFF
--- a/pkg/apis/core/v1alpha1/extensions_schedulingprofile.go
+++ b/pkg/apis/core/v1alpha1/extensions_schedulingprofile.go
@@ -25,7 +25,6 @@ func GetDefaultEnabledPlugins() *fedcore.EnabledPlugins {
 	filterPlugins := []string{
 		names.APIResources,
 		names.TaintToleration,
-		names.ClusterResourcesFit,
 		names.PlacementFilter,
 		names.ClusterAffinity,
 		names.ClusterReady,


### PR DESCRIPTION
Disable clusterResourcesFit filter plugin by default because in the scenario which cluster has autoscaler, cluster can scale up nodes to make unschedulable pods running.