### PR TITLE
refactor: replace runtime.Object with metav1.Object in pkg/util/finalizers

### DIFF
--- a/pkg/controllers/federate/controller.go
+++ b/pkg/controllers/federate/controller.go
@@ -417,17 +417,14 @@ func (c *FederateController) ensureFinalizer(
 ) (*unstructured.Unstructured, error) {
 	logger := klog.FromContext(ctx).WithValues("finalizer", FinalizerFederateController)
 
-	isUpdated, err := finalizersutil.AddFinalizers(sourceObj, sets.NewString(FinalizerFederateController))
-	if err != nil {
-		return nil, fmt.Errorf("failed to add finalizer to source object: %w", err)
-	}
+	isUpdated := finalizersutil.AddFinalizers(sourceObj, sets.New(FinalizerFederateController))
 	if !isUpdated {
 		return sourceObj, nil
 	}
 
 	logger.V(1).Info("Adding finalizer to source object")
 
-	sourceObj, err = c.dynamicClient.Resource(sourceGVR).Namespace(sourceObj.GetNamespace()).Update(
+	sourceObj, err := c.dynamicClient.Resource(sourceGVR).Namespace(sourceObj.GetNamespace()).Update(
 		ctx,
 		sourceObj,
 		metav1.UpdateOptions{},
@@ -446,17 +443,14 @@ func (c *FederateController) removeFinalizer(
 ) (*unstructured.Unstructured, error) {
 	logger := klog.FromContext(ctx).WithValues("finalizer", FinalizerFederateController)
 
-	isUpdated, err := finalizersutil.RemoveFinalizers(sourceObj, sets.NewString(FinalizerFederateController))
-	if err != nil {
-		return nil, fmt.Errorf("failed to remove finalizer from source object: %w", err)
-	}
+	isUpdated := finalizersutil.RemoveFinalizers(sourceObj, sets.New(FinalizerFederateController))
 	if !isUpdated {
 		return sourceObj, nil
 	}
 
 	logger.V(1).Info("Removing finalizer from source object")
 
-	sourceObj, err = c.dynamicClient.Resource(sourceGVR).Namespace(sourceObj.GetNamespace()).Update(
+	sourceObj, err := c.dynamicClient.Resource(sourceGVR).Namespace(sourceObj.GetNamespace()).Update(
 		ctx,
 		sourceObj,
 		metav1.UpdateOptions{},

--- a/pkg/controllers/federatedcluster/controller.go
+++ b/pkg/controllers/federatedcluster/controller.go
@@ -353,10 +353,7 @@ func (c *FederatedClusterController) ensureFinalizer(
 	ctx context.Context,
 	cluster *fedcorev1a1.FederatedCluster,
 ) (*fedcorev1a1.FederatedCluster, error) {
-	updated, err := finalizers.AddFinalizers(cluster, sets.NewString(FinalizerFederatedClusterController))
-	if err != nil {
-		return nil, err
-	}
+	updated := finalizers.AddFinalizers(cluster, sets.New(FinalizerFederatedClusterController))
 
 	if updated {
 		return c.fedClient.CoreV1alpha1().FederatedClusters().Update(ctx, cluster, metav1.UpdateOptions{})

--- a/pkg/controllers/sync/controller.go
+++ b/pkg/controllers/sync/controller.go
@@ -624,12 +624,7 @@ func (s *SyncController) syncToClusters(
 			)
 			continue
 		}
-		hasFinalizer, err := finalizersutil.HasFinalizer(cluster, FinalizerCascadingDelete)
-		if err != nil {
-			shouldRecheckAfterDispatch = true
-			dispatcher.RecordClusterError(fedcorev1a1.FinalizerCheckFailed, clusterName, err)
-			continue
-		}
+		hasFinalizer := finalizersutil.HasFinalizer(cluster, FinalizerCascadingDelete)
 		if !hasFinalizer {
 			// we should not sync before finalizer is added
 			shouldRecheckAfterDispatch = true
@@ -971,9 +966,9 @@ func (s *SyncController) ensureFinalizer(ctx context.Context, fedResource Federa
 	ctx, keyedLogger := logging.InjectLoggerValues(ctx, "finalizer-name", FinalizerSyncController)
 
 	obj := fedResource.Object()
-	isUpdated, err := finalizersutil.AddFinalizers(obj, sets.NewString(FinalizerSyncController))
-	if err != nil || !isUpdated {
-		return err
+	isUpdated := finalizersutil.AddFinalizers(obj, sets.New(FinalizerSyncController))
+	if !isUpdated {
+		return nil
 	}
 
 	keyedLogger.V(1).Info("Adding finalizer to federated object")
@@ -995,9 +990,9 @@ func (s *SyncController) removeFinalizer(ctx context.Context, fedResource Federa
 	ctx, keyedLogger := logging.InjectLoggerValues(ctx, "finalizer-name", FinalizerSyncController)
 
 	obj := fedResource.Object()
-	isUpdated, err := finalizersutil.RemoveFinalizers(obj, sets.NewString(FinalizerSyncController))
-	if err != nil || !isUpdated {
-		return err
+	isUpdated := finalizersutil.RemoveFinalizers(obj, sets.New(FinalizerSyncController))
+	if !isUpdated {
+		return nil
 	}
 
 	keyedLogger.V(1).Info("Removing finalizer from federated object")
@@ -1024,9 +1019,9 @@ func (s *SyncController) ensureClusterFinalizer(ctx context.Context, cluster *fe
 		if err != nil {
 			return err
 		}
-		isUpdated, err := finalizersutil.AddFinalizers(cluster, sets.NewString(FinalizerCascadingDelete))
-		if err != nil || !isUpdated {
-			return err
+		isUpdated := finalizersutil.AddFinalizers(cluster, sets.New(FinalizerCascadingDelete))
+		if !isUpdated {
+			return nil
 		}
 		cluster, err = s.fedClient.CoreV1alpha1().FederatedClusters().Update(ctx, cluster, metav1.UpdateOptions{})
 		return err
@@ -1046,9 +1041,9 @@ func (s *SyncController) removeClusterFinalizer(ctx context.Context, cluster *fe
 		if err != nil {
 			return err
 		}
-		isUpdated, err := finalizersutil.RemoveFinalizers(cluster, sets.NewString(FinalizerCascadingDelete))
-		if err != nil || !isUpdated {
-			return err
+		isUpdated := finalizersutil.RemoveFinalizers(cluster, sets.New(FinalizerCascadingDelete))
+		if !isUpdated {
+			return nil
 		}
 		cluster, err = s.fedClient.CoreV1alpha1().FederatedClusters().Update(ctx, cluster, metav1.UpdateOptions{})
 		return err

--- a/pkg/controllers/sync/resource.go
+++ b/pkg/controllers/sync/resource.go
@@ -177,9 +177,7 @@ func (r *federatedResource) ObjectForCluster(clusterName string) (*unstructured.
 			return nil, err
 		}
 
-		if err := addRetainObjectFinalizer(obj); err != nil {
-			return nil, err
-		}
+		addRetainObjectFinalizer(obj)
 	case common.ServiceGVK:
 		if err := dropServiceFields(obj); err != nil {
 			return nil, err
@@ -189,19 +187,14 @@ func (r *federatedResource) ObjectForCluster(clusterName string) (*unstructured.
 			return nil, err
 		}
 
-		if err := addRetainObjectFinalizer(obj); err != nil {
-			return nil, err
-		}
+		addRetainObjectFinalizer(obj)
 	}
 
 	return obj, nil
 }
 
-func addRetainObjectFinalizer(obj *unstructured.Unstructured) error {
-	if _, err := finalizers.AddFinalizers(obj, sets.NewString(dispatch.RetainTerminatingObjectFinalizer)); err != nil {
-		return err
-	}
-	return nil
+func addRetainObjectFinalizer(obj *unstructured.Unstructured) {
+	finalizers.AddFinalizers(obj, sets.New(dispatch.RetainTerminatingObjectFinalizer))
 }
 
 func dropJobFields(obj *unstructured.Unstructured) error {


### PR DESCRIPTION
This PR is to replace runtime.Object with metav1.Object in `pkg/util/finalizers`

related to #99