### PR TITLE
chore: fix receiver naming

### DIFF
--- a/pkg/apis/core/v1alpha1/extensions_propagationpolicy.go
+++ b/pkg/apis/core/v1alpha1/extensions_propagationpolicy.go
@@ -33,14 +33,14 @@ func (pp *PropagationPolicy) GetStatus() *PropagationPolicyStatus {
 	return &pp.Status
 }
 
-func (pp *ClusterPropagationPolicy) GetSpec() *PropagationPolicySpec {
-	return &pp.Spec
+func (cpp *ClusterPropagationPolicy) GetSpec() *PropagationPolicySpec {
+	return &cpp.Spec
 }
 
 func (cpp *ClusterPropagationPolicy) GetRefCountedStatus() *GenericRefCountedStatus {
 	return &cpp.Status.GenericRefCountedStatus
 }
 
-func (pp *ClusterPropagationPolicy) GetStatus() *PropagationPolicyStatus {
-	return &pp.Status
+func (cpp *ClusterPropagationPolicy) GetStatus() *PropagationPolicyStatus {
+	return &cpp.Status
 }


### PR DESCRIPTION
replace `pp` with `cpp` as the receiver name of ClusterPropagationPolicy:
1. keep the consistency with other place;
2. avoid the confusion with `pp` of PropagationPolicy.