### PR TITLE
fix: cascading deletion failed when mcs

### DIFF
--- a/pkg/apis/core/v1alpha1/extensions_federatedobject.go
+++ b/pkg/apis/core/v1alpha1/extensions_federatedobject.go
@@ -106,16 +106,16 @@ func (spec *GenericFederatedObjectSpec) SetControllerPlacement(controller string
 		}
 	}
 
-	newPlacmentWithController := PlacementWithController{
+	newPlacementWithController := PlacementWithController{
 		Controller: controller,
 		Placement:  newPlacement,
 	}
 	if oldPlacementWithControllerIdx == -1 {
-		spec.Placements = append(spec.Placements, newPlacmentWithController)
+		spec.Placements = append(spec.Placements, newPlacementWithController)
 		return true
 	}
-	if !reflect.DeepEqual(newPlacmentWithController, spec.Placements[oldPlacementWithControllerIdx]) {
-		spec.Placements[oldPlacementWithControllerIdx] = newPlacmentWithController
+	if !reflect.DeepEqual(newPlacementWithController, spec.Placements[oldPlacementWithControllerIdx]) {
+		spec.Placements[oldPlacementWithControllerIdx] = newPlacementWithController
 		return true
 	}
 

--- a/pkg/controllers/statusaggregator/controller.go
+++ b/pkg/controllers/statusaggregator/controller.go
@@ -463,30 +463,30 @@ func (a *StatusAggregator) reconcileOnClusterChange() {
 
 // getObjectFromStore returns the specified obj from cluster.
 // If cluster is "", get the obj from informerManager.
-func (a *StatusAggregator) getObjectFromStore(qualifedName reconcileKey, cluster string) (*unstructured.Unstructured, error) {
+func (a *StatusAggregator) getObjectFromStore(qualifiedName reconcileKey, cluster string) (*unstructured.Unstructured, error) {
 	var (
 		lister    cache.GenericLister
 		hasSynced cache.InformerSynced
 		exists    bool
 	)
 	if cluster != "" {
-		lister, hasSynced, exists = a.federatedInformer.GetResourceLister(qualifedName.gvk, cluster)
+		lister, hasSynced, exists = a.federatedInformer.GetResourceLister(qualifiedName.gvk, cluster)
 	} else {
-		lister, hasSynced, exists = a.informerManager.GetResourceLister(qualifedName.gvk)
+		lister, hasSynced, exists = a.informerManager.GetResourceLister(qualifiedName.gvk)
 	}
 	if !exists {
-		return nil, fmt.Errorf("lister for %s does not exist", qualifedName.gvk)
+		return nil, fmt.Errorf("lister for %s does not exist", qualifiedName.gvk)
 	}
 	if !hasSynced() {
-		return nil, fmt.Errorf("lister for %s not synced", qualifedName.gvk)
+		return nil, fmt.Errorf("lister for %s not synced", qualifiedName.gvk)
 	}
 
 	var obj pkgruntime.Object
 	var err error
-	if qualifedName.namespace == "" {
-		obj, err = lister.Get(qualifedName.name)
+	if qualifiedName.namespace == "" {
+		obj, err = lister.Get(qualifiedName.name)
 	} else {
-		obj, err = lister.ByNamespace(qualifedName.namespace).Get(qualifedName.name)
+		obj, err = lister.ByNamespace(qualifiedName.namespace).Get(qualifiedName.name)
 	}
 	if err != nil {
 		return nil, err

--- a/pkg/controllers/sync/controller.go
+++ b/pkg/controllers/sync/controller.go
@@ -1225,6 +1225,9 @@ func (s *SyncController) cascadingDeletionForFTC(
 
 		// get the corresponding federated object
 		fedObjName := naming.GenerateFederatedObjectName(clusterObj.GetName(), ftc.Name)
+		if util.IsDerivedService(clusterObj.GetAnnotations()) {
+			fedObjName = naming.GenerateDerivedSvcFedObjName(clusterObj.GetName())
+		}
 		fedObj, err := s.fedAccessor.FederatedResource(common.QualifiedName{
 			Namespace: clusterObj.GetNamespace(),
 			Name:      fedObjName,


### PR DESCRIPTION
When deleting derived services in cascade, the deletion cluster gets stuck because the corresponding federatedObj cannot be found.