### PR TITLE
fix: In e2e test, fedcorev1a1.PropagationPolicySpec.Placements should be a DesiredPlacement type, not ClusterReference type

### DIFF
--- a/test/e2e/framework/policies/propagationpolicy.go
+++ b/test/e2e/framework/policies/propagationpolicy.go
@@ -38,12 +38,12 @@ func PropagationPolicyForClustersWithPlacements(
 		},
 		Spec: fedcorev1a1.PropagationPolicySpec{
 			SchedulingMode: fedcorev1a1.SchedulingModeDuplicate,
-			Placements:     []fedcorev1a1.ClusterReference{},
+			Placements:     []fedcorev1a1.DesiredPlacement{},
 		},
 	}
 
 	for _, c := range clusters {
-		policy.Spec.Placements = append(policy.Spec.Placements, fedcorev1a1.ClusterReference{Cluster: c.Name})
+		policy.Spec.Placements = append(policy.Spec.Placements, fedcorev1a1.DesiredPlacement{Cluster: c.Name})
 	}
 
 	return policy


### PR DESCRIPTION
In e2e test, fedcorev1a1.PropagationPolicySpec.Placements should be a DesiredPlacement type, not ClusterReference type

*WHAT HAPPEND*

When I run `make e2e` to test official given testcase, the following problem arises：

``` shell
➜  kubeadmiral git:(main) ✗ make e2e                            
ginkgo run -race -tags=e2e  test/e2e -- --kubeconfig=/Users/fangxiaolong/.kube/kubeadmiral/kubeadmiral.config 
Failed to compile e2e:

# github.com/kubewharf/kubeadmiral/test/e2e/framework/policies
framework/policies/propagationpolicy.go:41:20: cannot use []fedcorev1a1.ClusterReference{} (value of type []"github.com/kubewharf/kubeadmiral/pkg/apis/core/v1alpha1".ClusterReference) as []"github.com/kubewharf/kubeadmiral/pkg/apis/core/v1alpha1".DesiredPlacement value in struct literal
framework/policies/propagationpolicy.go:46:59: cannot use fedcorev1a1.ClusterReference{…} (value of type "github.com/kubewharf/kubeadmiral/pkg/apis/core/v1alpha1".ClusterReference) as "github.com/kubewharf/kubeadmiral/pkg/apis/core/v1alpha1".DesiredPlacement value in argument to append


Ginkgo ran 1 suite in 36.335954166s

Test Suite Failed
make: *** [e2e] Error 1
```

This is obviously a type mismatch problem，it may be fixed by this PR.

In my env, this PR could fix the problem and work:

```shell
➜  kubeadmiral git:(main) ✗ EXTRA_GINKGO_FLAGS='' EXTRA_E2E_FLAGS='--cluster-provider kind' make e2e
ginkgo run -race -tags=e2e  test/e2e -- --kubeconfig=/Users/fangxiaolong/.kube/kubeadmiral/kubeadmiral.config --cluster-provider kind
Running Suite: KubeAdmiral E2E Tests - /Users/fangxiaolong/develop/kubeadmiral/test/e2e
=======================================================================================
Random Seed: 1718111501

Will run 3 of 3 specs
•••

Ran 3 of 3 Specs in 124.685 seconds
SUCCESS! -- 3 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS

Ginkgo ran 1 suite in 2m13.69917775s
Test Suite Passed
```