### PR TITLE
fix(override): support overwriting finalizers via OverridePolicy

### DIFF
--- a/pkg/controllers/sync/dispatch/retain.go
+++ b/pkg/controllers/sync/dispatch/retain.go
@@ -48,10 +48,9 @@ func RetainOrMergeClusterFields(
 	// Pass the same ResourceVersion as in the cluster object for update operation, otherwise operation will fail.
 	desiredObj.SetResourceVersion(clusterObj.GetResourceVersion())
 
-	// Retain finalizers and merge annotations since they will typically be set by
+	// Merge annotations since they will typically be set by
 	// controllers in a member cluster.  It is still possible to set the fields
 	// via overrides.
-	desiredObj.SetFinalizers(clusterObj.GetFinalizers())
 	mergeAnnotations(desiredObj, clusterObj)
 	mergeLabels(desiredObj, clusterObj)
 


### PR DESCRIPTION
Now you can use OP to overwrite finalizers like this:

```yaml
spec:
  overrideRules:
  - overriders:
      jsonpatch:
      - operator: add
        path: /metadata/finalizers/0
        value: aaa.bbb.ccc/test
      - operator: replace
        path: /metadata/finalizers/0
        value: aaa.bbb.ccc/new-test
      # you'd better replace it all instead of removing by index, 
      # because the syncer might remove multiple times by index.
      # - operator: replace 
      #   path: /metadata/finalizers   
      #   value: []
    targetClusters:
      clusters:
      - kubeadmiral-member-2
```

**NOTE:** if you have added new finalizers to member cluster's resources, you have to remove all finalizers before you can delete the resource from the member cluster.