### PR TITLE
feat：add rlock for string func

### DIFF
--- a/pkg/util/aggregatedlister/global_resource_version.go
+++ b/pkg/util/aggregatedlister/global_resource_version.go
@@ -76,6 +76,8 @@ func (g *GlobalResourceVersion) Get(cluster string) string {
 }
 
 func (g *GlobalResourceVersion) String() string {
+	g.RLock()
+	defer g.RUnlock()
 	if g.isZero {
 		return "0"
 	}


### PR DESCRIPTION
String func is also used in a multi-threaded environment, and rlock is required to avoid concurrent map reading and writing.
```
go func(cluster string) {
        ....
	if pod, ok := event.Object.(*corev1.Pod); ok {
		clusterobject.MakePodUnique(pod, cluster)
		retGrv.Set(cluster, pod.ResourceVersion)
		pod.SetResourceVersion(retGrv.String())
		event.Object = pod
	}

	lock.Lock()
	if !isProxyChClosed {
		proxyCh <- event
	}
	lock.Unlock()
      }
....
}(clusters[i].Name)
```