### PR TITLE
Fix(aggregatedlister): Add error logging to avoid silently ignoring cluster API request failures

### DIFF
--- a/pkg/util/aggregatedlister/service.go
+++ b/pkg/util/aggregatedlister/service.go
@@ -24,6 +24,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"context"
+    "github.com/kubewharf/kubeadmiral/pkg/util/logging"
 
 	"github.com/kubewharf/kubeadmiral/pkg/util/clusterobject"
 	"github.com/kubewharf/kubeadmiral/pkg/util/informermanager"
@@ -67,6 +69,9 @@ func (s *ServiceNamespaceLister) List(ctx context.Context, opts metav1.ListOptio
 			ResourceVersion: grv.Get(cluster.Name),
 		})
 		if err != nil {
+			logging.Errorf(ctx, "Failed to list services from cluster %s (namespace %s): %v",
+                cluster.Name, s.namespace, err,
+            )
 			continue
 		}
 		services := serviceList.Items


### PR DESCRIPTION
**Issue Description**  
In the `ServiceNamespaceLister.List` method, when a request to the member cluster's API Server for the Service list fails, the current code directly `continue`s without logging the error. This leads to the following issues:  
1. **Silent Failures**: Operators are unaware of request failures in specific clusters, which may cause resource synchronization anomalies (e.g., scheduling incidents as documented).  
2. **Debugging Difficulties**: Missing error context (e.g., cluster name, namespace) makes it challenging to quickly diagnose network issues or abnormal cluster states.  

**Proposed Changes**  
1. **Add Error Logging**: When `client.CoreV1().Services(...).List(...)` fails, log an error message containing critical context such as the cluster name and namespace.  
2. **Use Project-Unified Logging Tool**: To maintain code consistency, use the `github.com/kubewharf/kubeadmiral/pkg/util/logging` package (based on project dependencies) for logging.