### PR TITLE
fix: add some logs for hpa aggregator

### DIFF
--- a/pkg/registry/hpaaggregator/aggregation/forward/endpointSlice.go
+++ b/pkg/registry/hpaaggregator/aggregation/forward/endpointSlice.go
@@ -123,15 +123,26 @@ func (e *EndpointSliceREST) List(ctx context.Context, options *metainternalversi
 	if options != nil {
 		resourceVersion = options.ResourceVersion
 	}
+
+	ctx, logger := logging.InjectLoggerValues(
+		ctx,
+		"label_selector", label,
+		"field_selector", field,
+		"resourceVersion", resourceVersion,
+		"namespace", namespace,
+	)
+
+	logger.Info("Start to list endpointSlices in aggregation api")
 	objs, err := e.endpointSliceLister.ByNamespace(namespace).List(ctx, metav1.ListOptions{
 		LabelSelector:   label.String(),
 		FieldSelector:   field.String(),
 		ResourceVersion: resourceVersion,
 	})
 	if err != nil {
-		klog.ErrorS(err, "Failed listing endpointSlices", "namespace", klog.KRef("", namespace))
+		logger.Error(err, "Failed listing endpointSlices")
 		return nil, fmt.Errorf("failed listing endpointSlices: %w", err)
 	}
+	logger.Info("Successfully listed endpointSlices in aggregation api")
 	return objs, nil
 }
 
@@ -165,9 +176,10 @@ func (e *EndpointSliceREST) Watch(ctx context.Context, options *metainternalvers
 		"namespace", namespace,
 	)
 
+	logger.Info("Start to watch endpointSlices in aggregation api")
 	clusters, err := e.federatedInformerManager.GetReadyClusters()
 	if err != nil {
-		logger.Error(err, "Failed to get ready clusters")
+		logger.Error(err, "Failed to get ready clusters for watching endpointSlices")
 		return nil, fmt.Errorf("failed watching endpointSlices: %w", err)
 	}
 
@@ -179,6 +191,7 @@ func (e *EndpointSliceREST) Watch(ctx context.Context, options *metainternalvers
 	for i := range clusters {
 		client, exist := e.federatedInformerManager.GetClusterKubeClient(clusters[i].Name)
 		if !exist {
+			logger.Info("Failed to get cluster kubeClient", "cluster", clusters[i].Name)
 			continue
 		}
 		watcher, err := client.DiscoveryV1().EndpointSlices(namespace).Watch(ctx, metav1.ListOptions{
@@ -188,7 +201,7 @@ func (e *EndpointSliceREST) Watch(ctx context.Context, options *metainternalvers
 			ResourceVersion: grv.Get(clusters[i].Name),
 		})
 		if err != nil {
-			logger.Error(err, "Failed watching endpointSlices")
+			logger.Error(err, "Failed watching endpointSlices", "cluster", clusters[i].Name)
 			continue
 		}
 		go func(cluster string) {

--- a/pkg/registry/hpaaggregator/aggregation/forward/pod.go
+++ b/pkg/registry/hpaaggregator/aggregation/forward/pod.go
@@ -126,15 +126,25 @@ func (p *PodREST) List(ctx context.Context, options *metainternalversion.ListOpt
 		resourceVersion = options.ResourceVersion
 	}
 
+	ctx, logger := logging.InjectLoggerValues(
+		ctx,
+		"label_selector", label,
+		"field_selector", field,
+		"resourceVersion", resourceVersion,
+		"namespace", namespace,
+	)
+
+	logger.Info("Start to list pods in aggregation api")
 	objs, err := p.podLister.ByNamespace(namespace).List(ctx, metav1.ListOptions{
 		LabelSelector:   label.String(),
 		FieldSelector:   field.String(),
 		ResourceVersion: resourceVersion,
 	})
 	if err != nil {
-		klog.ErrorS(err, "Failed listing pods", "namespace", klog.KRef("", namespace))
+		logger.Error(err, "Failed listing pods")
 		return nil, fmt.Errorf("failed listing pods: %w", err)
 	}
+	logger.Info("Successfully listed pods in aggregation api")
 	return objs, nil
 }
 
@@ -168,9 +178,10 @@ func (p *PodREST) Watch(ctx context.Context, options *metainternalversion.ListOp
 		"namespace", namespace,
 	)
 
+	logger.Info("Start to watch pods in aggregation api")
 	clusters, err := p.federatedInformerManager.GetReadyClusters()
 	if err != nil {
-		logger.Error(err, "Failed to get ready clusters")
+		logger.Error(err, "Failed to get ready clusters for watching pods")
 		return nil, fmt.Errorf("failed watching pods: %w", err)
 	}
 
@@ -182,6 +193,7 @@ func (p *PodREST) Watch(ctx context.Context, options *metainternalversion.ListOp
 	for i := range clusters {
 		client, exist := p.federatedInformerManager.GetClusterKubeClient(clusters[i].Name)
 		if !exist {
+			logger.Info("Failed to get cluster kubeClient", "cluster", clusters[i].Name)
 			continue
 		}
 		watcher, err := client.CoreV1().Pods(namespace).Watch(ctx, metav1.ListOptions{
@@ -191,7 +203,7 @@ func (p *PodREST) Watch(ctx context.Context, options *metainternalversion.ListOp
 			ResourceVersion: grv.Get(clusters[i].Name),
 		})
 		if err != nil {
-			logger.Error(err, "Failed watching pods")
+			logger.Error(err, "Failed watching pods", "cluster", clusters[i].Name)
 			continue
 		}
 		go func(cluster string) {

--- a/pkg/registry/hpaaggregator/aggregation/forward/service.go
+++ b/pkg/registry/hpaaggregator/aggregation/forward/service.go
@@ -123,15 +123,26 @@ func (s *ServiceREST) List(ctx context.Context, options *metainternalversion.Lis
 	if options != nil {
 		resourceVersion = options.ResourceVersion
 	}
+
+	ctx, logger := logging.InjectLoggerValues(
+		ctx,
+		"label_selector", label,
+		"field_selector", field,
+		"resourceVersion", resourceVersion,
+		"namespace", namespace,
+	)
+
+	logger.Info("Start to list services in aggregation api")
 	objs, err := s.serviceLister.ByNamespace(namespace).List(ctx, metav1.ListOptions{
 		LabelSelector:   label.String(),
 		FieldSelector:   field.String(),
 		ResourceVersion: resourceVersion,
 	})
 	if err != nil {
-		klog.ErrorS(err, "Failed listing services", "namespace", klog.KRef("", namespace))
+		logger.Error(err, "Failed listing services")
 		return nil, fmt.Errorf("failed listing services: %w", err)
 	}
+	logger.Info("Successfully listed services in aggregation api")
 	return objs, nil
 }
 
@@ -165,9 +176,10 @@ func (s *ServiceREST) Watch(ctx context.Context, options *metainternalversion.Li
 		"namespace", namespace,
 	)
 
+	logger.Info("Start to watch services in aggregation api")
 	clusters, err := s.federatedInformerManager.GetReadyClusters()
 	if err != nil {
-		logger.Error(err, "Failed to get ready clusters")
+		logger.Error(err, "Failed to get ready clusters for watching services")
 		return nil, fmt.Errorf("failed watching services: %w", err)
 	}
 
@@ -179,6 +191,7 @@ func (s *ServiceREST) Watch(ctx context.Context, options *metainternalversion.Li
 	for i := range clusters {
 		client, exist := s.federatedInformerManager.GetClusterKubeClient(clusters[i].Name)
 		if !exist {
+			logger.Info("Failed to get cluster kubeClient", "cluster", clusters[i].Name)
 			continue
 		}
 		watcher, err := client.CoreV1().Services(namespace).Watch(ctx, metav1.ListOptions{
@@ -188,7 +201,7 @@ func (s *ServiceREST) Watch(ctx context.Context, options *metainternalversion.Li
 			ResourceVersion: grv.Get(clusters[i].Name),
 		})
 		if err != nil {
-			logger.Error(err, "Failed watching services")
+			logger.Error(err, "Failed watching services", "cluster", clusters[i].Name)
 			continue
 		}
 		go func(cluster string) {

--- a/pkg/util/aggregatedlister/endpointSlice.go
+++ b/pkg/util/aggregatedlister/endpointSlice.go
@@ -18,7 +18,6 @@ package aggregatedlister
 
 import (
 	"context"
-	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -28,6 +27,7 @@ import (
 
 	"github.com/kubewharf/kubeadmiral/pkg/util/clusterobject"
 	"github.com/kubewharf/kubeadmiral/pkg/util/informermanager"
+	"github.com/kubewharf/kubeadmiral/pkg/util/logging"
 )
 
 type EndpointSliceLister struct {
@@ -48,10 +48,18 @@ func (e *EndpointSliceLister) ByNamespace(namespace string) AggregatedNamespaceL
 }
 
 func (e *EndpointSliceNamespaceLister) List(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
+	ctx, logger := logging.InjectLoggerValues(
+		ctx,
+		"label_selector", opts.LabelSelector,
+		"field_selector", opts.FieldSelector,
+		"grv", opts.ResourceVersion,
+		"namespace", e.namespace,
+	)
 	grv := NewGlobalResourceVersionFromString(opts.ResourceVersion)
 	retGrv := grv.Clone()
 	clusters, err := e.federatedInformerManager.GetReadyClusters()
 	if err != nil {
+		logger.Error(err, "Failed to get ready clusters for listing endpointSlices")
 		return nil, err
 	}
 	var resultObject runtime.Object
@@ -59,7 +67,8 @@ func (e *EndpointSliceNamespaceLister) List(ctx context.Context, opts metav1.Lis
 	for _, cluster := range clusters {
 		client, exists := e.federatedInformerManager.GetClusterKubeClient(cluster.Name)
 		if !exists {
-			return nil, fmt.Errorf("failed to get cluster client of %s", cluster.Name)
+			logger.Info("Failed to get cluster kubeClient", "cluster", cluster.Name)
+			continue
 		}
 
 		endpointSliceList, err := client.DiscoveryV1().EndpointSlices(e.namespace).List(ctx, metav1.ListOptions{
@@ -68,13 +77,15 @@ func (e *EndpointSliceNamespaceLister) List(ctx context.Context, opts metav1.Lis
 			ResourceVersion: grv.Get(cluster.Name),
 		})
 		if err != nil {
-			return nil, err
+			logger.Error(err, "Failed to list endpointSlices", "cluster", cluster.Name)
+			continue
 		}
 		endpointSlices := endpointSliceList.Items
 
 		list, err := meta.ListAccessor(endpointSliceList)
 		if err != nil {
-			return nil, err
+			logger.Error(err, "Failed to convert endpointSliceList to list interface", "cluster", cluster.Name)
+			continue
 		}
 
 		if resultObject == nil {
@@ -103,10 +114,12 @@ func (e *EndpointSliceNamespaceLister) List(ctx context.Context, opts metav1.Lis
 
 	err = meta.SetList(resultObject, items)
 	if err != nil {
+		logger.Error(err, "Failed to set list object for endpointSliceList")
 		return nil, err
 	}
 	accessor, err := meta.ListAccessor(resultObject)
 	if err != nil {
+		logger.Error(err, "Failed to get accessor for endpointSliceList")
 		return nil, err
 	}
 	accessor.SetResourceVersion(retGrv.String())

--- a/pkg/util/aggregatedlister/pod.go
+++ b/pkg/util/aggregatedlister/pod.go
@@ -18,8 +18,6 @@ package aggregatedlister
 
 import (
 	"context"
-	"fmt"
-
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -28,6 +26,7 @@ import (
 
 	"github.com/kubewharf/kubeadmiral/pkg/util/clusterobject"
 	"github.com/kubewharf/kubeadmiral/pkg/util/informermanager"
+	"github.com/kubewharf/kubeadmiral/pkg/util/logging"
 )
 
 type PodLister struct {
@@ -49,10 +48,18 @@ func (p *PodLister) ByNamespace(namespace string) AggregatedNamespaceLister {
 }
 
 func (p *PodNamespaceLister) List(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
+	ctx, logger := logging.InjectLoggerValues(
+		ctx,
+		"label_selector", opts.LabelSelector,
+		"field_selector", opts.FieldSelector,
+		"grv", opts.ResourceVersion,
+		"namespace", p.namespace,
+	)
 	grv := NewGlobalResourceVersionFromString(opts.ResourceVersion)
 	retGrv := grv.Clone()
 	clusters, err := p.federatedInformerManager.GetReadyClusters()
 	if err != nil {
+		logger.Error(err, "Failed to get ready clusters for listing pods")
 		return nil, err
 	}
 	var resultObject runtime.Object
@@ -60,7 +67,8 @@ func (p *PodNamespaceLister) List(ctx context.Context, opts metav1.ListOptions) 
 	for _, cluster := range clusters {
 		client, exists := p.federatedInformerManager.GetClusterKubeClient(cluster.Name)
 		if !exists {
-			return nil, fmt.Errorf("failed to get cluster client of %s", cluster.Name)
+			logger.Info("Failed to get cluster kubeClient", "cluster", cluster.Name)
+			continue
 		}
 
 		podList, err := client.CoreV1().Pods(p.namespace).List(ctx, metav1.ListOptions{
@@ -69,13 +77,15 @@ func (p *PodNamespaceLister) List(ctx context.Context, opts metav1.ListOptions) 
 			ResourceVersion: grv.Get(cluster.Name),
 		})
 		if err != nil {
-			return nil, err
+			logger.Error(err, "Failed to list pods", "cluster", cluster.Name)
+			continue
 		}
 		pods := podList.Items
 
 		list, err := meta.ListAccessor(podList)
 		if err != nil {
-			return nil, err
+			logger.Error(err, "Failed to convert podList to list interface", "cluster", cluster.Name)
+			continue
 		}
 
 		if resultObject == nil {
@@ -104,10 +114,12 @@ func (p *PodNamespaceLister) List(ctx context.Context, opts metav1.ListOptions) 
 
 	err = meta.SetList(resultObject, items)
 	if err != nil {
+		logger.Error(err, "Failed to set list object for podList")
 		return nil, err
 	}
 	accessor, err := meta.ListAccessor(resultObject)
 	if err != nil {
+		logger.Error(err, "Failed to get accessor for podList")
 		return nil, err
 	}
 	accessor.SetResourceVersion(retGrv.String())

--- a/pkg/util/aggregatedlister/service.go
+++ b/pkg/util/aggregatedlister/service.go
@@ -18,7 +18,6 @@ package aggregatedlister
 
 import (
 	"context"
-	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -28,6 +27,7 @@ import (
 
 	"github.com/kubewharf/kubeadmiral/pkg/util/clusterobject"
 	"github.com/kubewharf/kubeadmiral/pkg/util/informermanager"
+	"github.com/kubewharf/kubeadmiral/pkg/util/logging"
 )
 
 type ServiceLister struct {
@@ -48,10 +48,18 @@ func (s *ServiceLister) ByNamespace(namespace string) AggregatedNamespaceLister 
 }
 
 func (s *ServiceNamespaceLister) List(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
+	ctx, logger := logging.InjectLoggerValues(
+		ctx,
+		"label_selector", opts.LabelSelector,
+		"field_selector", opts.FieldSelector,
+		"grv", opts.ResourceVersion,
+		"namespace", s.namespace,
+	)
 	grv := NewGlobalResourceVersionFromString(opts.ResourceVersion)
 	retGrv := grv.Clone()
 	clusters, err := s.federatedInformerManager.GetReadyClusters()
 	if err != nil {
+		logger.Error(err, "Failed to get ready clusters for listing services")
 		return nil, err
 	}
 	var resultObject runtime.Object
@@ -59,7 +67,8 @@ func (s *ServiceNamespaceLister) List(ctx context.Context, opts metav1.ListOptio
 	for _, cluster := range clusters {
 		client, exists := s.federatedInformerManager.GetClusterKubeClient(cluster.Name)
 		if !exists {
-			return nil, fmt.Errorf("failed to get cluster client of %s", cluster.Name)
+			logger.Info("Failed to get cluster kubeClient", "cluster", cluster.Name)
+			continue
 		}
 
 		serviceList, err := client.CoreV1().Services(s.namespace).List(ctx, metav1.ListOptions{
@@ -68,13 +77,15 @@ func (s *ServiceNamespaceLister) List(ctx context.Context, opts metav1.ListOptio
 			ResourceVersion: grv.Get(cluster.Name),
 		})
 		if err != nil {
-			return nil, err
+			logger.Error(err, "Failed to list services", "cluster", cluster.Name)
+			continue
 		}
 		services := serviceList.Items
 
 		list, err := meta.ListAccessor(serviceList)
 		if err != nil {
-			return nil, err
+			logger.Error(err, "Failed to convert serviceList to list interface", "cluster", cluster.Name)
+			continue
 		}
 
 		if resultObject == nil {
@@ -103,10 +114,12 @@ func (s *ServiceNamespaceLister) List(ctx context.Context, opts metav1.ListOptio
 
 	err = meta.SetList(resultObject, items)
 	if err != nil {
+		logger.Error(err, "Failed to set list object for serviceList")
 		return nil, err
 	}
 	accessor, err := meta.ListAccessor(resultObject)
 	if err != nil {
+		logger.Error(err, "Failed to get accessor for serviceList")
 		return nil, err
 	}
 	accessor.SetResourceVersion(retGrv.String())


### PR DESCRIPTION
In the past few weeks, we have been discussing whether to return an overall error or a partial return of the acquired cluster data when the federation side traverses the resources of all clusters in hpa-aggregator if one of the clusters list/watch fails. In the end, we decided to maintain the current implementation before there are actual implementation cases. 

In addition, we decided to add more logs to the entire multi-cluster link so that cluster administrators can locate problems earlier.